### PR TITLE
Fasten up execution by using pbkdf2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ version = "0.1.0-dev"
 dependencies = [
  "clap",
  "env_logger",
+ "eth2_key_derivation",
  "eth2_keystore",
  "eth2_network_config",
  "eth2_wallet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = "^2.33"
+eth2_key_derivation = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_wallet = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -1,4 +1,4 @@
-use crate::utils::wallet_password_bytes;
+use crate::utils::{pbkdf2, wallet_password_bytes};
 use eth2_keystore::{keypair_from_secret, Keystore, KeystoreBuilder};
 use eth2_wallet::{recover_validator_secret, KeyType};
 
@@ -19,8 +19,10 @@ pub(crate) fn wallet_to_keystores(
             let keypair = keypair_from_secret(voting_secret.as_bytes())
                 .expect("Can not initialize keypair from provided wallet");
 
+            // Use pbkdf2 crypt because it is faster
             KeystoreBuilder::new(&keypair, password, format!("{}", path))
                 .expect("Can not create KeystoreBuilder from provided wallet")
+                .kdf(pbkdf2())
                 .build()
                 .expect("Failed to build keystore")
         })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use eth2_keystore::json_keystore::{HexBytes, Kdf, Pbkdf2, Prf};
+use eth2_keystore::{DKLEN, SALT_SIZE};
 use rand::{distributions::Alphanumeric, Rng};
 
 lazy_static! {
@@ -13,4 +15,14 @@ lazy_static! {
 /// Convert random password into byte slices.
 pub(crate) fn wallet_password_bytes() -> [u8; 13] {
     WALLET_PASSWORD.as_slice().try_into().unwrap()
+}
+
+pub(crate) fn pbkdf2() -> Kdf {
+    let salt = rand::thread_rng().gen::<[u8; SALT_SIZE]>();
+    Kdf::Pbkdf2(Pbkdf2 {
+        dklen: DKLEN,
+        c: 262_144,
+        prf: Prf::HmacSha256,
+        salt: HexBytes::from(salt.to_vec()),
+    })
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,8 +1,16 @@
-use crate::utils::wallet_password_bytes;
-use bip39::{Language, Mnemonic, MnemonicType};
+use crate::utils::{pbkdf2, wallet_password_bytes};
+use bip39::{Language, Mnemonic, MnemonicType, Seed as Bip39Seed};
+use eth2_key_derivation::PlainText;
+use eth2_keystore::json_keystore::{Cipher, Kdf};
+use eth2_keystore::{encrypt, IV_SIZE};
+use eth2_wallet::json_wallet::{
+    Aes128Ctr, ChecksumModule, CipherModule, Crypto, EmptyMap, EmptyString, JsonWallet, KdfModule,
+    Sha256Checksum, TypeField, Version,
+};
 use eth2_wallet::{Error, Wallet};
+use rand::Rng;
+use uuid::Uuid;
 
-#[allow(dead_code)]
 pub(crate) fn get_eth2_wallet(existing_mnemonic: Option<&[u8]>) -> Result<(Wallet, String), Error> {
     let mnemonic = match existing_mnemonic {
         Some(found_mnemonic) => {
@@ -16,7 +24,7 @@ pub(crate) fn get_eth2_wallet(existing_mnemonic: Option<&[u8]>) -> Result<(Walle
     let pass = wallet_password_bytes();
     let wallet_name = uuid::Uuid::new_v4().to_string();
     let seed_phrase = mnemonic.clone().into_phrase();
-    let wb = eth2_wallet::WalletBuilder::from_mnemonic(&mnemonic, &pass, wallet_name)?;
+    let wb = WalletBuilder::from_mnemonic(&mnemonic, &pass, wallet_name)?;
     let wallet = match wb.build() {
         Ok(w) => w,
         Err(e) => {
@@ -24,6 +32,92 @@ pub(crate) fn get_eth2_wallet(existing_mnemonic: Option<&[u8]>) -> Result<(Walle
         }
     };
     Ok((wallet, seed_phrase))
+}
+
+pub struct WalletBuilder<'a> {
+    seed: PlainText,
+    password: &'a [u8],
+    kdf: Kdf,
+    cipher: Cipher,
+    uuid: Uuid,
+    name: String,
+    nextaccount: u32,
+}
+
+impl<'a> WalletBuilder<'a> {
+    /// Creates a new builder for a seed specified as a BIP-39 `Mnemonic` (where the nmemonic itself does
+    /// not have a passphrase).
+    ///
+    /// ## Errors
+    ///
+    /// Returns `Error::EmptyPassword` if `password == ""`.
+    pub fn from_mnemonic(
+        mnemonic: &Mnemonic,
+        password: &'a [u8],
+        name: String,
+    ) -> Result<Self, Error> {
+        let seed = Bip39Seed::new(mnemonic, "");
+
+        Self::from_seed_bytes(seed.as_bytes(), password, name)
+    }
+
+    /// Creates a new builder from a `seed` specified as a byte slice.
+    ///
+    /// ## Errors
+    ///
+    /// Returns `Error::EmptyPassword` if `password == ""`.
+    pub fn from_seed_bytes(seed: &[u8], password: &'a [u8], name: String) -> Result<Self, Error> {
+        if password.is_empty() {
+            Err(Error::EmptyPassword)
+        } else if seed.is_empty() {
+            Err(Error::EmptySeed)
+        } else {
+            let iv = rand::thread_rng().gen::<[u8; IV_SIZE]>().to_vec().into();
+
+            Ok(Self {
+                seed: seed.to_vec().into(),
+                password,
+                kdf: pbkdf2(),
+                cipher: Cipher::Aes128Ctr(Aes128Ctr { iv }),
+                uuid: Uuid::new_v4(),
+                nextaccount: 0,
+                name,
+            })
+        }
+    }
+
+    /// Consumes `self`, returning an encrypted `Wallet`.
+    pub fn build(self) -> Result<Wallet, Error> {
+        let (cipher_text, checksum) =
+            encrypt(self.seed.as_bytes(), self.password, &self.kdf, &self.cipher)?;
+
+        let json_wallet = JsonWallet {
+            crypto: Crypto {
+                kdf: KdfModule {
+                    function: self.kdf.function(),
+                    params: self.kdf,
+                    message: EmptyString,
+                },
+                checksum: ChecksumModule {
+                    function: Sha256Checksum::function(),
+                    params: EmptyMap,
+                    message: checksum.to_vec().into(),
+                },
+                cipher: CipherModule {
+                    function: self.cipher.function(),
+                    params: self.cipher,
+                    message: cipher_text.into(),
+                },
+            },
+            uuid: self.uuid,
+            nextaccount: self.nextaccount,
+            version: Version::one(),
+            type_field: TypeField::Hd,
+            name: self.name,
+        };
+        let wallet = Wallet::from_json_str(serde_json::to_string(&json_wallet).unwrap().as_str())?;
+        Ok(wallet)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Currently most of the generation time is spent in `scrypt()` function, which is pretty slow.

This changes password derivation method to `pbkdf2()` which allows to generate a validator in 30 seconds on my Mac.