### PR TITLE
Refactor keystore to get rid of additional decrypt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,11 @@ fn existing_mnemonic<'a>(sub_match: &ArgMatches<'a>) {
         .value_of("withdrawal_address")
         .expect("missing withdrawal address");
 
-    let mut validators = Validators::new(Some(mnemonic.as_bytes()), keystore_password.as_bytes());
-    validators.init_validators(num_validators);
+    let validators = Validators::new(
+        Some(mnemonic.as_bytes()),
+        keystore_password.as_bytes(),
+        Some(num_validators),
+    );
     let export = validators
         .export(
             chain.to_string(),


### PR DESCRIPTION
- Add `VotingKeyMaterial` wrapper struct to use in place of Lighthouse's `Keystore`, which carries plain text private key of a validator
- Get rid of additional keystore `.decrypt()` call on export, using private key of `VotingKeyMaterial`
- Thus, remove 30% of call length, now 1 validator is generated in less than 10 seconds on my Mac