### PR TITLE
new mnemonic command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,9 +597,11 @@ version = "0.1.0-dev"
 dependencies = [
  "clap",
  "env_logger",
+ "eth2_hashing",
  "eth2_key_derivation",
  "eth2_keystore",
  "eth2_network_config",
+ "eth2_ssz",
  "eth2_wallet",
  "hex",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = "^2.33"
+eth2_hashing = "0.3.0"
 eth2_key_derivation = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_keystore = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_network_config = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
+eth2_ssz = "0.4.1"
 eth2_wallet = { git = "https://github.com/sigp/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 env_logger = "^0.6.0"
 hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ To avoid heavy lifting, we're interfacing [Lighthouse account manager](https://g
 | Account   | public/private keypair that points to your funds        |
 | keystore file   | encrypted version of your private key in JSON funds        |
 | mnemonic phrase / seed phrase / seed words   | 12 or 24 word phrase to access infinite number of accounts, used to derive multiple private keys        |
-| seed   | input given to derive a private key (should be truly random!)        |
-| wallet password   |        |
+| seed   | secret value used to derive HD wallet addresses from a mnemonic phrase (BIP39 standard)       |
 | decryption key   |    used to encrypt/decrypt keystore file    |
 
 # Getting involved

--- a/src/cli/existing_mnemonic.rs
+++ b/src/cli/existing_mnemonic.rs
@@ -1,0 +1,109 @@
+use crate::Validators;
+use clap::{App, Arg, ArgMatches};
+
+#[allow(clippy::needless_lifetimes)]
+pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
+    App::new("existing-mnemonic")
+        .about("Generate (or recover) keys from an existing mnemonic.")
+        .arg(
+            Arg::with_name("mnemonic")
+                .long("mnemonic")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "The mnemonic that you used to generate your
+                keys. (It is recommended not to use this
+                argument, and wait for the CLI to ask you
+                for your mnemonic as otherwise it will
+                appear in your shell history.)",
+                ),
+        )
+        .arg(
+            Arg::with_name("num_validators")
+                .long("num_validators")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "The number of new validator keys you want to
+                generate (you can always generate more
+                later)",
+                ),
+        )
+        .arg(
+            Arg::with_name("chain")
+                .long("chain")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    r#"The name of Ethereum PoS chain you are
+                targeting. Use "mainnet" if you are
+                depositing ETH"#,
+                ),
+        )
+        .arg(
+            Arg::with_name("keystore_password")
+                .long("keystore_password")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "The password that will secure your
+                keystores. You will need to re-enter this to
+                decrypt them when you setup your Ethereum
+                validators. (It is recommended not to use
+                this argument, and wait for the CLI to ask
+                you for your mnemonic as otherwise it will
+                appear in your shell history.)",
+                ),
+        )
+        .arg(
+            Arg::with_name("withdrawal_address")
+                .long("withdrawal_address")
+                .required(false)
+                .takes_value(true)
+                .help(
+                    "If this field is set and valid, the given
+                address will be used to create the
+                withdrawal credentials. Otherwise, it will
+                generate withdrawal credentials with the
+                mnemonic-derived withdrawal public key.",
+                ),
+        )
+}
+
+#[allow(clippy::needless_lifetimes)]
+pub fn run<'a>(sub_match: &ArgMatches<'a>) {
+    let mnemonic = sub_match.value_of("mnemonic").unwrap();
+
+    let num_validators = sub_match
+        .value_of("num_validators")
+        .expect("missing number of validators")
+        .parse::<u32>()
+        .expect("invalid number of validators");
+
+    let chain = sub_match
+        .value_of("chain")
+        .expect("missing chain identifier");
+
+    let keystore_password = sub_match
+        .value_of("keystore_password")
+        .expect("missing keystore password");
+
+    let withdrawal_address = sub_match.value_of("withdrawal_address");
+
+    let validators = Validators::new(
+        Some(mnemonic.as_bytes()),
+        keystore_password.as_bytes(),
+        Some(num_validators),
+        withdrawal_address.is_none(),
+    );
+    let export = validators
+        .export(
+            chain.to_string(),
+            withdrawal_address,
+            32_000_000_000,
+            "2.3.0".to_string(),
+            None,
+        )
+        .unwrap();
+    println!("{}", export);
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,2 @@
+pub mod existing_mnemonic;
+pub mod new_mnemonic;

--- a/src/cli/new_mnemonic.rs
+++ b/src/cli/new_mnemonic.rs
@@ -1,0 +1,96 @@
+use crate::Validators;
+use clap::{App, Arg, ArgMatches};
+
+#[allow(clippy::needless_lifetimes)]
+pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
+    App::new("new-mnemonic")
+        .about("Generate new keys with new mnemonic.")
+        .arg(
+            Arg::with_name("num_validators")
+                .long("num_validators")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "The number of new validator keys you want to
+                generate (you can always generate more
+                later)",
+                ),
+        )
+        .arg(
+            Arg::with_name("chain")
+                .long("chain")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    r#"The name of Ethereum PoS chain you are
+                targeting. Use "mainnet" if you are
+                depositing ETH"#,
+                ),
+        )
+        .arg(
+            Arg::with_name("keystore_password")
+                .long("keystore_password")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "The password that will secure your
+                keystores. You will need to re-enter this to
+                decrypt them when you setup your Ethereum
+                validators. (It is recommended not to use
+                this argument, and wait for the CLI to ask
+                you for your mnemonic as otherwise it will
+                appear in your shell history.)",
+                ),
+        )
+        .arg(
+            Arg::with_name("withdrawal_address")
+                .long("withdrawal_address")
+                .required(false)
+                .takes_value(true)
+                .help(
+                    "If this field is set and valid, the given
+                address will be used to create the
+                withdrawal credentials. Otherwise, it will
+                generate withdrawal credentials with the
+                mnemonic-derived withdrawal public key.",
+                ),
+        )
+}
+
+#[allow(clippy::needless_lifetimes)]
+pub fn run<'a>(sub_match: &ArgMatches<'a>) {
+    let num_validators_str = sub_match
+        .value_of("num_validators")
+        .expect("missing number of validators");
+
+    let num_validators = num_validators_str
+        .parse::<u32>()
+        .expect("invalid number of validators");
+
+    let chain = sub_match
+        .value_of("chain")
+        .expect("missing chain identifier");
+
+    let keystore_password = sub_match
+        .value_of("keystore_password")
+        .expect("missing keystore password");
+
+    let withdrawal_address = sub_match.value_of("withdrawal_address");
+
+    let validators = Validators::new(
+        None,
+        keystore_password.as_bytes(),
+        Some(num_validators),
+        withdrawal_address.is_none(),
+    );
+    let export = validators
+        .export(
+            chain.to_string(),
+            withdrawal_address,
+            32_000_000_000,
+            "2.3.0".to_string(),
+            None,
+        )
+        .unwrap();
+    println!("{}", export);
+}

--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -3,12 +3,14 @@ use bip39::Seed as Bip39Seed;
 use eth2_key_derivation::DerivedKey;
 use eth2_keystore::{keypair_from_secret, Keystore, KeystoreBuilder, PlainText};
 use eth2_wallet::{KeyType, ValidatorPath};
+use types::{Keypair, PublicKey};
 
 /// Contains keystore encrypted with password, along with original voting secret.
 #[derive(PartialEq)]
-pub struct VotingKeyMaterial {
+pub struct KeyMaterial {
     pub keystore: Keystore,
     pub voting_secret: PlainText,
+    pub withdrawal_pk: Option<PublicKey>,
 }
 
 /// Given eth2 wallet seed, create N key material wrappers,
@@ -17,28 +19,49 @@ pub(crate) fn seed_to_keystores(
     seed: &Bip39Seed,
     n: u32,
     password: &[u8],
-) -> Vec<VotingKeyMaterial> {
+    derive_withdrawal: bool,
+) -> Vec<KeyMaterial> {
     (0..n)
         .map(|idx| {
             let master = DerivedKey::from_seed(seed.as_bytes()).expect("Invalid seed is provided");
-            let path = ValidatorPath::new(idx, KeyType::Voting);
-            let destination = path.iter_nodes().fold(master, |dk, i| dk.child(*i));
-            let voting_secret: PlainText = destination.secret().to_vec().into();
-
-            let keypair = keypair_from_secret(voting_secret.as_bytes())
-                .expect("Can not initialize keypair from provided seed");
+            let (voting_path, voting_secret, keypair) =
+                derive_keypair(master, idx, KeyType::Voting);
             let keystore = // Use pbkdf2 crypt because it is faster
-            KeystoreBuilder::new(&keypair, password, format!("{}", path))
+            KeystoreBuilder::new(&keypair, password, format!("{}", voting_path))
                 .expect("Can not create KeystoreBuilder from provided seed")
                 .kdf(pbkdf2())
                 .build()
                 .expect("Failed to build keystore");
-            VotingKeyMaterial {
+
+            let withdrawal_pk = if derive_withdrawal {
+                let master =
+                    DerivedKey::from_seed(seed.as_bytes()).expect("Invalid seed is provided");
+                let (_, _, withdrawal_keypair) = derive_keypair(master, idx, KeyType::Withdrawal);
+                Some(withdrawal_keypair.pk)
+            } else {
+                None
+            };
+
+            KeyMaterial {
                 keystore,
                 voting_secret,
+                withdrawal_pk,
             }
         })
         .collect()
+}
+
+fn derive_keypair(
+    master: DerivedKey,
+    idx: u32,
+    key_type: KeyType,
+) -> (ValidatorPath, PlainText, Keypair) {
+    let voting_path = ValidatorPath::new(idx, key_type);
+    let voting_destination = voting_path.iter_nodes().fold(master, |dk, i| dk.child(*i));
+    let voting_secret: PlainText = voting_destination.secret().to_vec().into();
+    let keypair = keypair_from_secret(voting_secret.as_bytes())
+        .expect("Can not initialize keypair from provided seed");
+    (voting_path, voting_secret, keypair)
 }
 
 #[cfg(test)]
@@ -60,7 +83,7 @@ mod test {
     #[test]
     fn test_seed_to_keystore() {
         let seed = seed_from_mnemonic();
-        let keystores = seed_to_keystores(&seed, 2, VOTING_KEYSTORE_PASSWORD);
+        let keystores = seed_to_keystores(&seed, 2, VOTING_KEYSTORE_PASSWORD, false);
 
         assert_eq!(keystores.len(), 2);
 
@@ -83,5 +106,28 @@ mod test {
             "3f3e0a69a6a66aeaec606a2ccb47c703afb2e8ae64f70a1650c03343b06e8f0c",
             hex::encode(secret_key.as_bytes())
         );
+    }
+
+    #[test]
+    fn test_seed_to_keystore_derive_withdrawal_key() {
+        let seed = seed_from_mnemonic();
+        let keystores = seed_to_keystores(&seed, 2, VOTING_KEYSTORE_PASSWORD, true);
+
+        assert_eq!(keystores.len(), 2);
+
+        let key_material = keystores.get(0).unwrap();
+
+        // Keys asserted here are generated with
+        // python ./staking_deposit/deposit.py existing-mnemonic --eth1_withdrawal_address 0x0000000000000000000000000000000000000001 --keystore_password test
+
+        // **[Warning] you are setting an Eth1 address as your withdrawal address. Please ensure that you have control over this address.**
+
+        // Please enter your mnemonic separated by spaces (" "): entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup
+        // Enter the index (key number) you wish to start generating more keys from. For example, if you've generated 4 keys in the past, you'd enter 4 here. [0]: 0
+        // Please choose how many new validators you wish to run: 1
+        // Please choose the (mainnet or testnet) network/chain name ['mainnet', 'prater', 'kintsugi', 'kiln', 'minimal']:  [mainnet]: minimal
+
+        assert_eq!(key_material.keystore.pubkey(), "8666389c3fe6ff0bca9adba81504f380b9e2c719419760d561836472fafe295cb50696524e19cba084e1d788d66c80d6");
+        assert_eq!(key_material.withdrawal_pk.as_ref().unwrap().to_string(), "0x8478fed8676e9e5d0376c2da97a9e2d67ff5aa11b312aca7856b29f595fcf2c5909c8bafce82f46d9888cd18f780e302");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cli;
 pub(crate) mod deposit;
 pub(crate) mod keystore;
 pub(crate) mod seed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use clap::{App, Arg, ArgMatches};
-use eth_staking_smith::Validators;
+use clap::App;
+use eth_staking_smith::cli::{existing_mnemonic, new_mnemonic};
 
 fn main() {
     env_logger::init();
@@ -7,121 +7,13 @@ fn main() {
         .version(env!("CARGO_PKG_VERSION"))
         .author(&*format!("Chorus one <{}>", env!("CARGO_PKG_AUTHORS")))
         .about(env!("CARGO_PKG_DESCRIPTION"))
-        .subcommand(existing_mnemonic_subcommand())
+        .subcommand(new_mnemonic::subcommand())
+        .subcommand(existing_mnemonic::subcommand())
         .get_matches();
 
     match matches.subcommand() {
-        ("existing-mnemonic", Some(sub_match)) => existing_mnemonic(sub_match),
+        ("new-mnemonic", Some(sub_match)) => new_mnemonic::run(sub_match),
+        ("existing-mnemonic", Some(sub_match)) => existing_mnemonic::run(sub_match),
         _ => println!("{}", matches.usage()),
     }
-}
-
-#[allow(clippy::needless_lifetimes)]
-pub fn existing_mnemonic_subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("existing-mnemonic")
-        .about("Generate (or recover) keys from an existing mnemonic.")
-        .arg(
-            Arg::with_name("mnemonic")
-                .long("mnemonic")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "The mnemonic that you used to generate your
-                keys. (It is recommended not to use this
-                argument, and wait for the CLI to ask you
-                for your mnemonic as otherwise it will
-                appear in your shell history.)",
-                ),
-        )
-        .arg(
-            Arg::with_name("num_validators")
-                .long("num_validators")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "The number of new validator keys you want to
-                generate (you can always generate more
-                later)",
-                ),
-        )
-        .arg(
-            Arg::with_name("chain")
-                .long("chain")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    r#"The name of Ethereum PoS chain you are
-                targeting. Use "mainnet" if you are
-                depositing ETH"#,
-                ),
-        )
-        .arg(
-            Arg::with_name("keystore_password")
-                .long("keystore_password")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "The password that will secure your
-                keystores. You will need to re-enter this to
-                decrypt them when you setup your Ethereum
-                validators. (It is recommended not to use
-                this argument, and wait for the CLI to ask
-                you for your mnemonic as otherwise it will
-                appear in your shell history.)",
-                ),
-        )
-        .arg(
-            Arg::with_name("withdrawal_address")
-                .long("withdrawal_address")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "If this field is set and valid, the given
-                Eth1 address will be used to create the
-                withdrawal credentials. Otherwise, it will
-                generate withdrawal credentials with the
-                mnemonic-derived withdrawal public key.",
-                ),
-        )
-}
-
-#[allow(clippy::needless_lifetimes)]
-fn existing_mnemonic<'a>(sub_match: &ArgMatches<'a>) {
-    let mnemonic = sub_match.value_of("mnemonic").unwrap();
-
-    let num_validators_str = sub_match
-        .value_of("num_validators")
-        .expect("missing number of validators");
-
-    let num_validators = num_validators_str
-        .parse::<u32>()
-        .expect("invalid number of validators");
-
-    let chain = sub_match
-        .value_of("chain")
-        .expect("missing chain identifier");
-
-    let keystore_password = sub_match
-        .value_of("keystore_password")
-        .expect("missing keystore password");
-
-    let withdrawal_address = sub_match
-        .value_of("withdrawal_address")
-        .expect("missing withdrawal address");
-
-    let validators = Validators::new(
-        Some(mnemonic.as_bytes()),
-        keystore_password.as_bytes(),
-        Some(num_validators),
-    );
-    let export = validators
-        .export(
-            chain.to_string(),
-            withdrawal_address.to_string(),
-            32_000_000_000,
-            "2.3.0".to_string(),
-            None,
-        )
-        .unwrap();
-    println!("{}", export);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,9 @@
+use eth2_hashing::hash;
 use eth2_keystore::json_keystore::{HexBytes, Kdf, Pbkdf2, Prf};
 use eth2_keystore::{DKLEN, SALT_SIZE};
 use rand::Rng;
+use ssz::Encode;
+use types::PublicKey;
 
 pub(crate) fn pbkdf2() -> Kdf {
     let salt = rand::thread_rng().gen::<[u8; SALT_SIZE]>();
@@ -10,4 +13,15 @@ pub(crate) fn pbkdf2() -> Kdf {
         prf: Prf::HmacSha256,
         salt: HexBytes::from(salt.to_vec()),
     })
+}
+
+/// Returns the withdrawal credentials for a given public key.
+///
+/// Used for submitting deposits to the Eth1 deposit contract.
+pub(crate) fn get_withdrawal_credentials(pubkey: &PublicKey, prefix_byte: u8) -> Vec<u8> {
+    let hashed = hash(&pubkey.as_ssz_bytes());
+    let mut prefixed = vec![prefix_byte];
+    prefixed.extend_from_slice(&hashed[1..]);
+
+    prefixed
 }

--- a/src/validators.rs
+++ b/src/validators.rs
@@ -1,23 +1,23 @@
 use crate::deposit::{keystore_to_deposit, DepositError};
-use crate::keystore::{seed_to_keystores, VotingKeyMaterial};
+use crate::keystore::{seed_to_keystores, KeyMaterial};
 use crate::seed::get_eth2_seed;
 use bip39::{Mnemonic, Seed as Bip39Seed};
 use eth2_keystore::Keystore;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tree_hash::TreeHash;
 
 pub struct Validators<'a> {
     mnemonic_phrase: String,
-    key_material: Vec<VotingKeyMaterial>,
+    key_material: Vec<KeyMaterial>,
     password: &'a [u8],
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct MnemonicExport {
     seed: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct DepositExport {
     pubkey: String,
     withdrawal_credentials: String,
@@ -30,7 +30,7 @@ struct DepositExport {
     deposit_cli_version: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct ValidatorExports {
     keystores: Vec<Keystore>,
     private_keys: Vec<String>,
@@ -45,9 +45,15 @@ impl<'a> Validators<'a> {
         seed: &'a Bip39Seed,
         password: &'a [u8],
         num_validators: Option<u32>,
-    ) -> Vec<VotingKeyMaterial> {
+        derive_withdrawal: bool,
+    ) -> Vec<KeyMaterial> {
         let mut key_material = vec![];
-        for voting_keystore in seed_to_keystores(seed, num_validators.unwrap_or(1), password) {
+        for voting_keystore in seed_to_keystores(
+            seed,
+            num_validators.unwrap_or(1),
+            password,
+            derive_withdrawal,
+        ) {
             key_material.push(voting_keystore);
         }
         key_material
@@ -58,12 +64,18 @@ impl<'a> Validators<'a> {
         mnemonic_phrase: Option<&[u8]>,
         password: &'a [u8],
         num_validators: Option<u32>,
+        derive_withdrawal: bool,
     ) -> Self {
         let (seed, phrase_string) = get_eth2_seed(mnemonic_phrase);
 
         Self {
             mnemonic_phrase: phrase_string,
-            key_material: Validators::key_material_from_seed(&seed, password, num_validators),
+            key_material: Validators::key_material_from_seed(
+                &seed,
+                password,
+                num_validators,
+                derive_withdrawal,
+            ),
             password,
         }
     }
@@ -73,12 +85,18 @@ impl<'a> Validators<'a> {
         mnemonic: &'a Mnemonic,
         password: &'a [u8],
         num_validators: Option<u32>,
+        derive_withdrawal: bool,
     ) -> Self {
         let mnemonic_phrase = mnemonic.clone().into_phrase();
         let (seed, _) = get_eth2_seed(Some(mnemonic.clone().into_phrase().as_str().as_bytes()));
         Self {
             mnemonic_phrase,
-            key_material: Validators::key_material_from_seed(&seed, password, num_validators),
+            key_material: Validators::key_material_from_seed(
+                &seed,
+                password,
+                num_validators,
+                derive_withdrawal,
+            ),
             password,
         }
     }
@@ -118,7 +136,7 @@ impl<'a> Validators<'a> {
     pub fn export(
         &self,
         network: String,
-        withdrawal_credentials: String,
+        withdrawal_credentials: Option<&str>,
         deposit_amount_gwei: u64,
         deposit_cli_version: String,
         chain_spec_file: Option<String>,
@@ -131,11 +149,18 @@ impl<'a> Validators<'a> {
             let keystore = key_with_store.keystore.clone();
             keystores.push(keystore.clone());
             private_keys.push(hex::encode(key_with_store.voting_secret.as_bytes()));
+
+            let withdrawal_credentials = if withdrawal_credentials.is_some() {
+                Some(withdrawal_credentials.as_ref().unwrap().as_bytes())
+            } else {
+                None
+            };
             let public_key = keystore.pubkey().to_string();
             let (deposit, chain_spec) = keystore_to_deposit(
                 keystore.clone(),
                 self.password,
-                withdrawal_credentials.as_bytes(),
+                withdrawal_credentials,
+                key_with_store.withdrawal_pk.clone(),
                 deposit_amount_gwei,
                 network.clone(),
                 chain_spec_file.clone(),
@@ -174,23 +199,39 @@ impl<'a> Validators<'a> {
 #[cfg(test)]
 mod test {
 
+    use crate::validators::ValidatorExports;
+
     use super::Validators;
     use test_log::test;
 
     const PHRASE: &str = "entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup";
 
     #[test]
-    fn test_export_validators() {
-        let validators = Validators::new(Some(PHRASE.as_bytes()), "test".as_bytes(), Some(1));
-        let export = validators
-            .export(
-                "mainnet".to_string(),
-                "0100000000000000000000000000000000000000000000000000000000000001".to_string(),
-                32_000_000_000,
-                "2.3.0".to_string(),
-                None,
-            )
-            .unwrap();
+    fn test_export_validators_existing_mnemonic() {
+        fn validators_with_mnemonic() -> Validators<'static> {
+            Validators::new(Some(PHRASE.as_bytes()), "test".as_bytes(), Some(1), false)
+        }
+
+        let exports = vec![
+            validators_with_mnemonic()
+                .export(
+                    "mainnet".to_string(),
+                    Some("0100000000000000000000000000000000000000000000000000000000000001"),
+                    32_000_000_000,
+                    "2.3.0".to_string(),
+                    None,
+                )
+                .unwrap(),
+            validators_with_mnemonic()
+                .export(
+                    "mainnet".to_string(),
+                    Some("0100000000000000000000000000000000000000000000000000000000000001"),
+                    32_000_000_000,
+                    "2.3.0".to_string(),
+                    None,
+                )
+                .unwrap(),
+        ];
 
         let expect_pks = r#""private_keys": [
     "3f3e0a69a6a66aeaec606a2ccb47c703afb2e8ae64f70a1650c03343b06e8f0c"
@@ -213,10 +254,95 @@ mod test {
       "deposit_cli_version": "2.3.0"
     }
   ]"#;
-        log::debug!("Export: {}", export);
-        // Asserts are for parts of string, cause keystore has different salt all the time.
-        assert!(export.contains(expect_pks));
-        assert!(export.contains(expect_mnemonic));
-        assert!(export.contains(expect_deposit_data));
+        // existing-mnemonic is deterministic, therefore both exports should be as expected
+        for export in exports {
+            // Asserts are for parts of string, cause keystore has different salt all the time.
+            assert!(export.contains(expect_pks));
+            assert!(export.contains(expect_mnemonic));
+            assert!(export.contains(expect_deposit_data));
+        }
+    }
+
+    #[test]
+    fn test_export_validators_new_mnemonic() {
+        fn validators_new_mnemonic() -> Validators<'static> {
+            Validators::new(None, "test".as_bytes(), Some(1), false)
+        }
+
+        let exports: Vec<ValidatorExports> = vec![
+            serde_json::from_str(
+                &validators_new_mnemonic()
+                    .export(
+                        "mainnet".to_string(),
+                        Some("0100000000000000000000000000000000000000000000000000000000000001"),
+                        32_000_000_000,
+                        "2.3.0".to_string(),
+                        None,
+                    )
+                    .unwrap(),
+            )
+            .unwrap(),
+            serde_json::from_str(
+                &validators_new_mnemonic()
+                    .export(
+                        "mainnet".to_string(),
+                        Some("0100000000000000000000000000000000000000000000000000000000000001"),
+                        32_000_000_000,
+                        "2.3.0".to_string(),
+                        None,
+                    )
+                    .unwrap(),
+            )
+            .unwrap(),
+        ];
+
+        for export in exports.iter() {
+            // new-mnemonic generates keys, therefore only the assertions below should be equal
+            assert_eq!(
+                export.deposit_data.get(0).unwrap().withdrawal_credentials,
+                "0100000000000000000000000000000000000000000000000000000000000001"
+            );
+            assert_eq!(export.deposit_data.get(0).unwrap().network_name, "mainnet");
+            assert_eq!(export.deposit_data.get(0).unwrap().amount, 32000000000);
+        }
+
+        // new-mnemonic assert that keys are different
+        assert_ne!(
+            exports.get(0).unwrap().private_keys,
+            exports.get(1).unwrap().private_keys
+        );
+    }
+
+    #[test]
+    fn test_export_validators_no_withdrawal_credentials() {
+        let validators = Validators::new(Some(PHRASE.as_bytes()), "test".as_bytes(), Some(1), true);
+
+        let export = validators
+            .export(
+                "mainnet".to_string(),
+                None,
+                32_000_000_000,
+                "2.3.0".to_string(),
+                None,
+            )
+            .unwrap();
+
+        let expect_deposit_data = r#""deposit_data": [
+    {
+      "pubkey": "8666389c3fe6ff0bca9adba81504f380b9e2c719419760d561836472fafe295cb50696524e19cba084e1d788d66c80d6",
+      "withdrawal_credentials": "00e078f11bc1454244bdf9f63a3b997815f081dd6630204186d4c9627a2942f7",
+      "amount": 32000000000,
+      "signature": "8fb5a76232cb613c30e02b5946d252d0cc5ed8cfa81b7a1f781dc4f228c5e89e77b5b745fba4371be8ea7f02f6b7e18e0e3661b04a63d51197bd43b9dea27fef97b8e2b94ffc989fc29484537bfed9f99b6bc57b45c2004dd23e1502006640d4",
+      "deposit_message_root": "9720268f705275b44bf4a7cd35246277f408dd245aafc676a3c335f1d714e724",
+      "deposit_data_root": "270169ee3da4da7566daa4a29727b893bb1c6ce2f26b6c861afe6d480b3f9a7d",
+      "fork_version": "00000000",
+      "network_name": "mainnet",
+      "deposit_cli_version": "2.3.0"
+    }
+  ]"#;
+
+        println!("export: {}", export);
+
+        export.contains(expect_deposit_data);
     }
 }


### PR DESCRIPTION
- [X] add new command to generate new mnemonics
- [X] make withdrawal address optional *
- [x] add tests

* for our current use case when generating keys with new mnemonics we don't pass in a withdrawal address, therefore need to make it optional. left it optional for both commands though in case we do want to change it in our current implementation. if no withdrawal address is passed in it is instead derived from the withdrawal public key