### PR TITLE
command for converting withdrawal address, e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,10 +120,22 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
- "funty",
- "radium",
+ "funty 1.1.0",
+ "radium 0.6.2",
  "tap",
- "wyz",
+ "wyz 0.2.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty 2.0.0",
+ "radium 0.7.0",
+ "tap",
+ "wyz 0.5.1",
 ]
 
 [[package]]
@@ -305,8 +317,8 @@ name = "compare_fields_derive"
 version = "0.2.0"
 source = "git+https://github.com/ChorusOne/lighthouse?rev=df51a73272489fe154bd10995c96199062b6c3f7#df51a73272489fe154bd10995c96199062b6c3f7"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -418,8 +430,8 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -462,10 +474,10 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "strsim 0.10.0",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -475,8 +487,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
- "quote",
- "syn",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -495,9 +507,23 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
+dependencies = [
+ "lazy_static",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "regex",
+ "rustc_version",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -584,7 +610,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
 dependencies = [
- "bitvec",
+ "bitvec 0.20.4",
  "ff",
  "generic-array",
  "group",
@@ -633,6 +659,7 @@ version = "0.1.0-dev"
 dependencies = [
  "assert_cmd",
  "clap",
+ "derive_more",
  "env_logger",
  "eth2_hashing",
  "eth2_key_derivation",
@@ -640,8 +667,10 @@ dependencies = [
  "eth2_network_config",
  "eth2_ssz",
  "eth2_wallet",
+ "ethereum-types",
  "getrandom 0.2.8",
  "hex",
+ "lazy_static",
  "log",
  "predicates",
  "pretty_assertions",
@@ -649,6 +678,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "ssz-rs",
+ "ssz-rs-derive",
  "test-log",
  "tiny-bip39",
  "tree_hash",
@@ -767,9 +798,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "635b86d2c941bb71e7419a571e1763d65c93e51a1bafc400352e3bef6ff59fc9"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -856,7 +887,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
- "bitvec",
+ "bitvec 0.20.4",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -903,6 +934,12 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -1062,9 +1099,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1324,7 +1361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec",
- "bitvec",
+ "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -1338,9 +1375,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1480,6 +1517,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
@@ -1495,11 +1541,20 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.47",
 ]
 
 [[package]]
@@ -1507,6 +1562,12 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1705,6 +1766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1813,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "serde"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,9 +1842,9 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1779,9 +1864,9 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1801,9 +1886,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1892,6 +1977,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssz-rs"
+version = "0.8.0"
+source = "git+https://github.com/ralexstokes/ssz-rs.git?rev=cb08f18ca919cc1b685b861d0fa9e2daabe89737#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
+dependencies = [
+ "bitvec 1.0.1",
+ "hex",
+ "lazy_static",
+ "num-bigint",
+ "serde",
+ "sha2 0.9.9",
+ "ssz-rs-derive",
+ "thiserror",
+]
+
+[[package]]
+name = "ssz-rs-derive"
+version = "0.8.0"
+source = "git+https://github.com/ralexstokes/ssz-rs.git?rev=cb08f18ca919cc1b685b861d0fa9e2daabe89737#cb08f18ca919cc1b685b861d0fa9e2daabe89737"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,10 +2033,10 @@ checksum = "95a99807a055ff4ff5d249bb84c80d9eabb55ca3c452187daae43fd5b51ef695"
 dependencies = [
  "darling",
  "itertools",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "smallvec",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1940,12 +2050,23 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
  "unicode-ident",
 ]
 
@@ -1955,10 +2076,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -2002,9 +2123,9 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2012,8 +2133,8 @@ name = "test_random_derive"
 version = "0.2.0"
 source = "git+https://github.com/ChorusOne/lighthouse?rev=df51a73272489fe154bd10995c96199062b6c3f7#df51a73272489fe154bd10995c96199062b6c3f7"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2040,9 +2161,9 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2134,8 +2255,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd22d128157837a4434bb51119aef11103f17bfe8c402ce688cf25aa1e608ad"
 dependencies = [
  "darling",
- "quote",
- "syn",
+ "quote 1.0.21",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2223,6 +2344,12 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -2307,9 +2434,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -2319,7 +2446,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote",
+ "quote 1.0.21",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2329,9 +2456,9 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2458,6 +2585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,9 +2623,9 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
  "synstructure",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,20 +14,25 @@ path = "src/lib.rs"
 
 [dependencies]
 clap = "^2.33"
+derive_more = "0.15"
 eth2_hashing = "0.3.0"
 eth2_key_derivation = { git = "https://github.com/ChorusOne/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_keystore = { git = "https://github.com/ChorusOne/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_network_config = { git = "https://github.com/ChorusOne/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 eth2_ssz = "0.4.1"
 eth2_wallet = { git = "https://github.com/ChorusOne/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
+ethereum-types = { version = "0.12.1", optional = true }
 env_logger = "^0.6.0"
 hex = "0.4"
+lazy_static = "1.4"
 log = "^0.4"
 getrandom = "0.2"
 regex = "1.5.5"
 serde = "1.0.115"
 serde_derive = "1.0"
 serde_json = "1.0"
+ssz-rs = { git = "https://github.com/ralexstokes/ssz-rs.git", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
+ssz-rs-derive = { git = "https://github.com/ralexstokes/ssz-rs.git", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 tiny-bip39 = "^0.8.0"
 tree_hash = { git = "https://github.com/ChorusOne/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}
 types = { git = "https://github.com/ChorusOne/lighthouse", rev = "df51a73272489fe154bd10995c96199062b6c3f7"}

--- a/src/bls_to_execution_change.rs
+++ b/src/bls_to_execution_change.rs
@@ -1,0 +1,315 @@
+use std::str::FromStr;
+
+use crate::{key_material, seed::get_eth2_seed, utils::get_withdrawal_credentials};
+use lazy_static::lazy_static;
+use regex::Regex;
+use ssz_rs::prelude::*;
+use types::{Hash256, Keypair, PublicKey, SecretKey, Signature};
+
+const DOMAIN_LEN: usize = 32;
+const DOMAIN_TYPE_LEN: usize = 4;
+const BLS_PUBKEY_LEN: usize = 96;
+const EXECUTION_ADDR_LEN: usize = 40;
+type DomainType = Vector<u8, DOMAIN_TYPE_LEN>;
+type Domain = Vector<u8, DOMAIN_LEN>;
+type Version = Vector<u8, 4>;
+type BLSPubkey = Vector<u8, BLS_PUBKEY_LEN>;
+type ExecutionAddress = Vector<u8, EXECUTION_ADDR_LEN>;
+
+lazy_static! {
+    static ref DOMAIN_BLS_TO_EXECUTION_CHANGE: DomainType =
+        Vector::<u8, DOMAIN_TYPE_LEN>::deserialize(&[0x0A, 0, 0, 0])
+            .expect("failed to deserialize");
+}
+
+#[derive(SimpleSerialize, Default)]
+pub struct ForkData {
+    current_version: Version,
+    genesis_validators_root: Node,
+}
+
+#[derive(SimpleSerialize, Default)]
+pub struct SigningData {
+    object_root: Node,
+    domain: Domain,
+}
+
+#[derive(Clone)]
+pub struct BLSToExecutionRequest {
+    validator_index: u32,
+    bls_keys: Keypair,
+    to_execution_address: ExecutionAddress,
+}
+
+#[derive(SimpleSerialize, Default, Clone, Debug)]
+pub struct BLSToExecutionChange {
+    validator_index: u32,
+    from_bls_pubkey: BLSPubkey,
+    to_execution_address: ExecutionAddress,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignedBLSToExecutionChange {
+    message: BLSToExecutionChange,
+    signature: Signature,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct BLSToExecutionChangeExport {
+    pub validator_index: u32,
+    pub from_bls_pubkey: String,
+    pub to_execution_address: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SignedBLSToExecutionChangeExport {
+    pub message: BLSToExecutionChangeExport,
+    pub signature: String,
+}
+
+impl SignedBLSToExecutionChange {
+    pub fn validate(self, from_bls_withdrawal_credentials: &str, to_execution_address: &str) {
+        // execution address is same as input
+        let execution_address = std::str::from_utf8(&self.message.to_execution_address).unwrap();
+        assert_eq!(to_execution_address, format!("0x{}", execution_address));
+
+        // withdrawal credentials are the same as input
+        let withdrawal_pubkey = std::str::from_utf8(&self.message.from_bls_pubkey).unwrap();
+        let withdrawal_pubkey = PublicKey::from_str(&format!("0x{}", withdrawal_pubkey)).unwrap();
+
+        let withdrawal_credentials = hex::encode(get_withdrawal_credentials(&withdrawal_pubkey, 0));
+        let withdrawal_credentials =
+            std::str::from_utf8(withdrawal_credentials.as_bytes()).unwrap();
+
+        assert_eq!(
+            from_bls_withdrawal_credentials,
+            format!("0x{}", withdrawal_credentials)
+        );
+
+        // verify signature
+
+        // FIXME: fork version hardcoded for mainnet
+        let fork_version = Vector::<u8, DOMAIN_TYPE_LEN>::deserialize(&[0x03, 0, 0, 0])
+            .expect("failed to deserialize");
+
+        // FIXME: genesis_validators_root hardcoded
+        let domain = compute_domain(
+            &DOMAIN_BLS_TO_EXECUTION_CHANGE,
+            fork_version,
+            Node::from_bytes(Hash256::zero().0),
+        )
+        .expect("could not compute domain");
+
+        let signing_root = compute_signing_root(self.message.clone(), domain)
+            .expect("could not compute signing root");
+
+        self.signature.verify(
+            &withdrawal_pubkey,
+            Hash256::from_slice(signing_root.as_bytes()),
+        );
+    }
+
+    pub fn export(&self) -> SignedBLSToExecutionChangeExport {
+        let withdrawal_pubkey = std::str::from_utf8(&self.message.from_bls_pubkey).unwrap();
+        let withdrawal_pubkey = PublicKey::from_str(&format!("0x{}", withdrawal_pubkey)).unwrap();
+
+        let withdrawal_credentials = hex::encode(get_withdrawal_credentials(&withdrawal_pubkey, 0));
+        let withdrawal_credentials =
+            std::str::from_utf8(withdrawal_credentials.as_bytes()).unwrap();
+
+        let to_execution_address = std::str::from_utf8(&self.message.to_execution_address).unwrap();
+
+        SignedBLSToExecutionChangeExport {
+            message: BLSToExecutionChangeExport {
+                validator_index: self.message.validator_index,
+                from_bls_pubkey: format!("0x{}", withdrawal_credentials),
+                to_execution_address: format!("0x{}", to_execution_address),
+            },
+            signature: self.signature.to_string(),
+        }
+    }
+}
+
+impl BLSToExecutionRequest {
+    pub fn new(
+        mnemonic_phrase: &[u8],
+        validator_start_index: u32,
+        execution_address: &str,
+    ) -> Self {
+        let (seed, _) = get_eth2_seed(Some(mnemonic_phrase));
+
+        let execution_addr_regex: Regex = Regex::new(r"^(0x[a-fA-F0-9]{40})$").unwrap();
+
+        if !execution_addr_regex.is_match(execution_address) {
+            panic!(
+                "Invalid execution address: Please pass in a valid execution address with the correct format"
+            );
+        }
+
+        let execution_address = Vector::<u8, EXECUTION_ADDR_LEN>::deserialize(
+            execution_address.strip_prefix("0x").unwrap().as_bytes(),
+        )
+        .expect("failed to deserialize");
+
+        let key_materials =
+            key_material::seed_to_key_material(&seed, 1, validator_start_index, None, true, None);
+
+        let key_material = key_materials
+            .get(0)
+            .expect("Error deriving key material from mnemonic");
+
+        BLSToExecutionRequest {
+            validator_index: validator_start_index,
+            bls_keys: key_material
+                .withdrawal_keypair
+                .clone()
+                .expect("Error deriving key material from mnemonic"),
+            to_execution_address: execution_address,
+        }
+    }
+
+    pub fn sign(self) -> SignedBLSToExecutionChange {
+        let withdrawal_pubkey = Vector::<u8, BLS_PUBKEY_LEN>::deserialize(
+            self.bls_keys
+                .pk
+                .to_string()
+                .strip_prefix("0x")
+                .unwrap()
+                .as_bytes(),
+        )
+        .expect("failed to deserialize");
+
+        let message = BLSToExecutionChange {
+            validator_index: self.validator_index,
+            from_bls_pubkey: withdrawal_pubkey,
+            to_execution_address: self.to_execution_address,
+        };
+
+        let secret_key = self.bls_keys.sk.serialize();
+
+        let withdrawal_privkey = secret_key.as_bytes();
+
+        generate_signed_bls_to_execution_change(message, withdrawal_privkey)
+            .expect("error generating signing bls to execution change")
+    }
+}
+
+fn generate_signed_bls_to_execution_change(
+    message: BLSToExecutionChange,
+    secret_key: &[u8],
+) -> Result<SignedBLSToExecutionChange, Box<dyn std::error::Error>> {
+    // FIXME: hardcoded for mainnet
+    let fork_version = Vector::<u8, DOMAIN_TYPE_LEN>::deserialize(&[0x03, 0, 0, 0])
+        .expect("failed to deserialize");
+
+    // FIXME: hardcoded for mainnet
+    let domain = compute_domain(
+        &DOMAIN_BLS_TO_EXECUTION_CHANGE,
+        fork_version,
+        Node::from_bytes(Hash256::zero().0),
+    )?;
+
+    let signing_root = compute_signing_root(message.clone(), domain)?;
+
+    let signature = sign(secret_key, signing_root)?;
+
+    Ok(SignedBLSToExecutionChange { message, signature })
+}
+
+/// based on https://github.com/ethereum/consensus-specs/blob/02b32100ed26c3c7a4a44f41b932437859487fd2/specs/phase0/beacon-chain.md#compute_domain
+fn compute_domain(
+    domain_type: &DomainType,
+    fork_version: Version,
+    genesis_validators_root: Node,
+) -> Result<Domain, MerkleizationError> {
+    let fork_data_root = compute_fork_data_root(fork_version, genesis_validators_root)?;
+    let mut bytes = Vec::new();
+    domain_type.serialize(&mut bytes)?;
+    fork_data_root.serialize(&mut bytes)?;
+    Ok(Vector::deserialize(&bytes[0..DOMAIN_LEN]).expect("invalid domain data"))
+}
+
+/// based on https://github.com/ethereum/consensus-specs/blob/02b32100ed26c3c7a4a44f41b932437859487fd2/specs/phase0/beacon-chain.md#compute_fork_data_root
+fn compute_fork_data_root(
+    current_version: Version,
+    genesis_validators_root: Node,
+) -> Result<Node, MerkleizationError> {
+    ForkData {
+        current_version,
+        genesis_validators_root,
+    }
+    .hash_tree_root()
+}
+
+/// based on https://github.com/ethereum/consensus-specs/blob/02b32100ed26c3c7a4a44f41b932437859487fd2/specs/phase0/beacon-chain.md#compute_signing_root
+pub fn compute_signing_root<T: SimpleSerialize>(
+    mut ssz_object: T,
+    domain: Domain,
+) -> Result<Node, MerkleizationError> {
+    SigningData {
+        object_root: ssz_object.hash_tree_root()?,
+        domain,
+    }
+    .hash_tree_root()
+}
+
+/// based on https://github.com/ethereum/consensus-specs/blob/02b32100ed26c3c7a4a44f41b932437859487fd2/specs/phase0/beacon-chain.md#bls-signatures
+fn sign(secret_key: &[u8], msg: Node) -> Result<Signature, Box<dyn std::error::Error>> {
+    let secret_key = SecretKey::deserialize(secret_key).expect("couldn't load the key");
+    let message = Hash256::from_slice(msg.as_bytes());
+    Ok(secret_key.sign(message))
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use types::{Hash256, PublicKey};
+
+    use crate::utils;
+
+    use super::BLSToExecutionRequest;
+
+    const EXECUTION_WITHDRAWAL_ADDRESS: &str = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    const PHRASE: &str = "entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup";
+
+    #[test]
+    fn it_generates_signed_bls_to_execution_change() {
+        // Keys asserted here are generated with the staking-deposit cli
+        // ./deposit existing-mnemonic --keystore_password testtest
+
+        // Please enter your mnemonic separated by spaces (" "): entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup
+        // Enter the index (key number) you wish to start generating more keys from. For example, if you've generated 4 keys in the past, you'd enter 4 here. [0]: 0
+        // Please choose how many new validators you wish to run: 1
+        // Please choose the (mainnet or testnet) network/chain name ['mainnet', 'prater', 'kintsugi', 'kiln', 'minimal']:  [mainnet]: minimal
+
+        fn withdrawal_creds_from_pk(withdrawal_pk: &PublicKey) -> String {
+            let withdrawal_creds = utils::get_withdrawal_credentials(&withdrawal_pk, 0);
+            let credentials_hash = Hash256::from_slice(&withdrawal_creds);
+            hex::encode(&credentials_hash.as_bytes())
+        }
+
+        let bls_to_execution_change =
+            BLSToExecutionRequest::new(PHRASE.as_bytes(), 0, EXECUTION_WITHDRAWAL_ADDRESS);
+        let signed_bls_to_execution_change = bls_to_execution_change.sign();
+
+        // format generated fields for assertion
+        let to_execution_address =
+            std::str::from_utf8(&signed_bls_to_execution_change.message.to_execution_address)
+                .unwrap();
+
+        let withdrawal_pub_key_str =
+            std::str::from_utf8(&signed_bls_to_execution_change.message.from_bls_pubkey).unwrap();
+        let withdrawal_pub_key =
+            PublicKey::from_str(&format!("0x{}", withdrawal_pub_key_str)).unwrap();
+
+        assert_eq!(
+            EXECUTION_WITHDRAWAL_ADDRESS,
+            format!("0x{}", to_execution_address)
+        );
+        assert_eq!(
+            "00e078f11bc1454244bdf9f63a3b997815f081dd6630204186d4c9627a2942f7",
+            withdrawal_creds_from_pk(&withdrawal_pub_key)
+        );
+    }
+}

--- a/src/cli/bls_to_execution_change.rs
+++ b/src/cli/bls_to_execution_change.rs
@@ -1,0 +1,99 @@
+use crate::bls_to_execution_change;
+use clap::{App, Arg, ArgMatches};
+
+#[allow(clippy::needless_lifetimes)]
+pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
+    App::new("bls-to-execution-change")
+        .about("Generates a SignedBLSToExecutionChange object which can be sent to the Beacon Node to change the withdrawal address from BLS to an execution address.")
+        .arg(
+            Arg::with_name("mnemonic")
+                .long("mnemonic")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "The mnemonic that you used to generate your
+                keys. (It is recommended not to use this
+                argument, and wait for the CLI to ask you
+                for your mnemonic as otherwise it will
+                appear in your shell history.)",
+                ),
+        )
+        .arg(
+            Arg::with_name("chain")
+                .long("chain")
+                .required(true)
+                .takes_value(true)
+                .possible_values(&["goerli", "prater", "mainnet", "minimal"])
+                .help(
+                    r#"The name of Ethereum PoS chain you are
+                targeting. Use "mainnet" if you are
+                depositing ETH"#,
+                ),
+        )
+        .arg(
+            Arg::with_name("validator_index")
+                .long("validator_index")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "The index of the first validator's keys you wish to generate the address for
+                e.g. if you generated 3 keys before (index #0, index #1, index #2) 
+                and you want to generate for the 2nd validator, 
+                the validator_index would be 1. 
+                If no index specified, it will be set to 0.",
+                ),
+        )
+        .arg(
+            Arg::with_name("bls_withdrawal_credentials")
+                .long("bls_withdrawal_credentials")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "BLS withdrawal credentials you used when depositing the validator.",
+                ),
+        )
+        .arg(
+            Arg::with_name("execution_address")
+                .long("execution_address")
+                .required(true)
+                .takes_value(true)
+                .help(
+                    "Execution (0x01) address to which funds withdrawn should be sent to.",
+                ),
+        )
+}
+
+#[allow(clippy::needless_lifetimes)]
+pub fn run<'a>(sub_match: &ArgMatches<'a>) {
+    let mnemonic = sub_match.value_of("mnemonic").unwrap();
+
+    let _chain = sub_match
+        .value_of("chain")
+        .expect("missing chain identifier");
+
+    let validator_index = sub_match
+        .value_of("validator_index")
+        .map(|idx| idx.parse::<u32>().expect("invalid validator index"))
+        .unwrap_or(0);
+
+    let execution_address = sub_match.value_of("execution_address").unwrap();
+    let bls_withdrawal_credentials = sub_match.value_of("bls_withdrawal_credentials").unwrap();
+
+    let bls_to_execution_change = bls_to_execution_change::BLSToExecutionRequest::new(
+        mnemonic.as_bytes(),
+        validator_index,
+        execution_address,
+    );
+
+    let signed_bls_to_execution_change = bls_to_execution_change.sign();
+
+    signed_bls_to_execution_change
+        .clone()
+        .validate(bls_withdrawal_credentials, execution_address);
+
+    let export = signed_bls_to_execution_change.export();
+
+    let signed_bls_to_execution_change_json =
+        serde_json::to_string_pretty(&export).expect("could not parse validator export");
+    println!("{}", signed_bls_to_execution_change_json);
+}

--- a/src/cli/bls_to_execution_change.rs
+++ b/src/cli/bls_to_execution_change.rs
@@ -67,7 +67,7 @@ pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
 pub fn run<'a>(sub_match: &ArgMatches<'a>) {
     let mnemonic = sub_match.value_of("mnemonic").unwrap();
 
-    let _chain = sub_match
+    let chain = sub_match
         .value_of("chain")
         .expect("missing chain identifier");
 
@@ -85,11 +85,13 @@ pub fn run<'a>(sub_match: &ArgMatches<'a>) {
         execution_address,
     );
 
-    let signed_bls_to_execution_change = bls_to_execution_change.sign();
+    let signed_bls_to_execution_change = bls_to_execution_change.sign(chain);
 
-    signed_bls_to_execution_change
-        .clone()
-        .validate(bls_withdrawal_credentials, execution_address);
+    signed_bls_to_execution_change.clone().validate(
+        bls_withdrawal_credentials,
+        execution_address,
+        chain,
+    );
 
     let export = signed_bls_to_execution_change.export();
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,3 @@
+pub mod bls_to_execution_change;
 pub mod existing_mnemonic;
 pub mod new_mnemonic;

--- a/src/deposit.rs
+++ b/src/deposit.rs
@@ -126,7 +126,7 @@ mod test {
             keystore: Some(keystore.clone()),
             keypair: keypair.clone(),
             voting_secret: PlainText::from(keypair.sk.serialize().as_bytes().to_vec()),
-            withdrawal_pk: None,
+            withdrawal_keypair: None,
         };
         let (deposit_data, _) = keystore_to_deposit(
             &key_material,
@@ -165,7 +165,7 @@ mod test {
             keystore: Some(keystore.clone()),
             keypair: keypair.clone(),
             voting_secret: PlainText::from(keypair.sk.serialize().as_bytes().to_vec()),
-            withdrawal_pk: None,
+            withdrawal_keypair: None,
         };
         let withdrawal_creds = hex::decode(WITHDRAWAL_CREDENTIALS_ETH2).unwrap();
         let (deposit_data, _) = keystore_to_deposit(
@@ -205,7 +205,7 @@ mod test {
             keystore: Some(keystore.clone()),
             keypair: keypair.clone(),
             voting_secret: PlainText::from(keypair.sk.serialize().as_bytes().to_vec()),
-            withdrawal_pk: Some(pk.clone()),
+            withdrawal_keypair: Some(keypair.clone()),
         };
         let withdrawal_creds = get_withdrawal_credentials(&pk, 0);
         let (deposit_data, _) = keystore_to_deposit(
@@ -252,7 +252,7 @@ mod test {
                     .as_bytes()
                     .to_vec(),
             ),
-            withdrawal_pk: None,
+            withdrawal_keypair: None,
         };
         let withdrawal_creds = hex::decode(WITHDRAWAL_CREDENTIALS_ETH2).unwrap();
         let (deposit_data, _) = keystore_to_deposit(
@@ -287,7 +287,7 @@ mod test {
             keystore: Some(keystore.clone()),
             keypair: keypair.clone(),
             voting_secret: PlainText::from(keypair.sk.serialize().as_bytes().to_vec()),
-            withdrawal_pk: None,
+            withdrawal_keypair: None,
         };
         let withdrawal_creds = hex::decode(WITHDRAWAL_CREDENTIALS_ETH2).unwrap();
         let (deposit_data, _) = keystore_to_deposit(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bls_to_execution_change;
 pub mod cli;
 pub(crate) mod deposit;
 pub(crate) mod key_material;
@@ -7,3 +8,6 @@ pub mod validators;
 
 pub use deposit::DepositError;
 pub use validators::*;
+
+#[macro_use]
+extern crate serde_derive;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::App;
-use eth_staking_smith::cli::{existing_mnemonic, new_mnemonic};
+use eth_staking_smith::cli::{bls_to_execution_change, existing_mnemonic, new_mnemonic};
 
 fn main() {
     env_logger::init();
@@ -9,11 +9,13 @@ fn main() {
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .subcommand(new_mnemonic::subcommand())
         .subcommand(existing_mnemonic::subcommand())
+        .subcommand(bls_to_execution_change::subcommand())
         .get_matches();
 
     match matches.subcommand() {
         ("new-mnemonic", Some(sub_match)) => new_mnemonic::run(sub_match),
         ("existing-mnemonic", Some(sub_match)) => existing_mnemonic::run(sub_match),
+        ("bls-to-execution-change", Some(sub_match)) => bls_to_execution_change::run(sub_match),
         _ => println!("{}", matches.usage()),
     }
 }

--- a/src/validators.rs
+++ b/src/validators.rs
@@ -11,8 +11,8 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tree_hash::TreeHash;
 use types::{
-    DepositData, Hash256, MainnetEthSpec, PublicKey, PublicKeyBytes, Signature, SignatureBytes,
-    SignedRoot,
+    DepositData, Hash256, Keypair, MainnetEthSpec, PublicKey, PublicKeyBytes, Signature,
+    SignatureBytes, SignedRoot,
 };
 
 const ETH1_CREDENTIALS_PREFIX: &[u8] = &[
@@ -252,7 +252,7 @@ impl Validators {
 
             let withdrawal_credentials = set_withdrawal_credentials(
                 withdrawal_credentials,
-                key_with_store.withdrawal_pk.clone(),
+                key_with_store.withdrawal_keypair.clone(),
             )?;
 
             let public_key = key_with_store.keypair.pk.as_hex_string().replace("0x", "");
@@ -296,7 +296,7 @@ impl Validators {
 
 fn set_withdrawal_credentials(
     existing_withdrawal_credentials: Option<&str>,
-    derived_withdrawal_credentials: Option<PublicKey>,
+    derived_withdrawal_credentials: Option<Keypair>,
 ) -> Result<Vec<u8>, DepositError> {
     let withdrawal_credentials = match existing_withdrawal_credentials {
         Some(creds) => {
@@ -324,7 +324,7 @@ fn set_withdrawal_credentials(
         }
         None => {
             let withdrawal_pk = match derived_withdrawal_credentials {
-                Some(pk) => pk,
+                Some(pk) => pk.pk,
                 None => {
                     return Err(DepositError::InvalidWithdrawalCredentials(
                         "Could not retrieve withdrawal public key from key matieral".to_string(),
@@ -348,9 +348,8 @@ mod test {
     };
 
     use super::Validators;
-    use std::str::FromStr;
     use test_log::test;
-    use types::PublicKey;
+    use types::Keypair;
 
     const PHRASE: &str = "entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup";
 
@@ -665,8 +664,8 @@ mod test {
 
     #[test]
     fn set_withdrawal_credentials_from_public_key() {
-        let pk = PublicKey::from_str(&"0x8478fed8676e9e5d0376c2da97a9e2d67ff5aa11b312aca7856b29f595fcf2c5909c8bafce82f46d9888cd18f780e302").unwrap();
-        let response = set_withdrawal_credentials(None, Some(pk));
+        let keypair = Keypair::random();
+        let response = set_withdrawal_credentials(None, Some(keypair));
         assert!(response.is_ok());
     }
 }

--- a/tests/e2e/bls_to_execution_change.rs
+++ b/tests/e2e/bls_to_execution_change.rs
@@ -1,0 +1,54 @@
+use assert_cmd::prelude::*;
+use eth_staking_smith::bls_to_execution_change::SignedBLSToExecutionChangeExport;
+use std::process::Command;
+
+/*
+    create SignedBLSToExecutionChange message for existing mnemonic
+*/
+#[test]
+fn test_bls_to_execution_change() -> Result<(), Box<dyn std::error::Error>> {
+    let chain = "goerli";
+    let expected_mnemonic = "ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say";
+    let validator_index = "0";
+    let execution_address = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
+    let bls_withdrawal_credentials =
+        "0x0045b91b2f60b88e7392d49ae1364b55e713d06f30e563f9f99e10994b26221d";
+    // run eth-staking-smith
+    let mut cmd = Command::cargo_bin("eth-staking-smith")?;
+
+    cmd.arg("bls-to-execution-change");
+    cmd.arg("--chain");
+    cmd.arg(chain);
+    cmd.arg("--validator_index");
+    cmd.arg(validator_index);
+    cmd.arg("--mnemonic");
+    cmd.arg(expected_mnemonic);
+    cmd.arg("--bls_withdrawal_credentials");
+    cmd.arg(bls_withdrawal_credentials);
+    cmd.arg("--execution_address");
+    cmd.arg(execution_address);
+
+    cmd.assert().success();
+
+    // read generated output
+
+    let output = &cmd.output()?.stdout;
+    let command_output = std::str::from_utf8(output)?;
+
+    let signed_bls_to_execution_change: SignedBLSToExecutionChangeExport =
+        serde_json::from_str(command_output)?;
+
+    assert_eq!(0, signed_bls_to_execution_change.message.validator_index);
+    assert_eq!(
+        "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+        signed_bls_to_execution_change.message.to_execution_address
+    );
+    assert_eq!(
+        "0x0045b91b2f60b88e7392d49ae1364b55e713d06f30e563f9f99e10994b26221d",
+        signed_bls_to_execution_change.message.from_bls_pubkey
+    );
+
+    Ok(())
+}
+
+// negative test inputs

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,3 +1,4 @@
+mod bls_to_execution_change;
 mod existing_mnemonic;
 mod new_mnemonic;
 


### PR DESCRIPTION
- [x] add new command to generate SignedBLSToExecutionChange
- [x] e2e test 
- [x] configure for other networks (currently hardcoded for mainnet) 

[Implementation from staking-deposit-cli](https://github.com/ethereum/staking-deposit-cli/tree/bls-to-execution-change) works as follows: 
- takes the following parameters as input: bls_to_execution_changes_folder, chain, fork, mnemonic, mnemonic_password, validator_start_index, validator_index, bls_withdrawal_credentials, execution_address
- read from input directory
- validates incoming withdrawal credentials 
- writes SignedBLSToExecutionChange for each address in directory