### PR TITLE
Upgrade git dependencies to get vulnerability fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,8 +175,9 @@ dependencies = [
 [[package]]
 name = "bls"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
+ "arbitrary",
  "blst",
  "eth2_hashing",
  "eth2_serde_utils",
@@ -260,7 +270,7 @@ dependencies = [
 [[package]]
 name = "cached_tree_hash"
 version = "0.1.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "eth2_hashing",
  "eth2_ssz",
@@ -276,6 +286,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -310,12 +323,12 @@ dependencies = [
 [[package]]
 name = "compare_fields"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 
 [[package]]
 name = "compare_fields_derive"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "quote 1.0.26",
  "syn 1.0.109",
@@ -326,6 +339,12 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cpufeatures"
@@ -518,6 +537,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2 1.0.52",
+ "quote 1.0.26",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
 dependencies = [
  "proc-macro2 1.0.52",
  "quote 1.0.26",
@@ -728,7 +758,7 @@ dependencies = [
 [[package]]
 name = "eth2_config"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "paste",
  "types",
@@ -737,7 +767,7 @@ dependencies = [
 [[package]]
 name = "eth2_hashing"
 version = "0.3.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "cpufeatures",
  "lazy_static",
@@ -748,7 +778,7 @@ dependencies = [
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "bls",
  "eth2_hashing",
@@ -763,7 +793,7 @@ dependencies = [
 [[package]]
 name = "eth2_key_derivation"
 version = "0.1.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "bls",
  "num-bigint-dig",
@@ -775,7 +805,7 @@ dependencies = [
 [[package]]
 name = "eth2_keystore"
 version = "0.1.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "aes",
  "bls",
@@ -797,7 +827,7 @@ dependencies = [
 [[package]]
 name = "eth2_network_config"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "enr",
  "eth2_config",
@@ -810,7 +840,7 @@ dependencies = [
 [[package]]
 name = "eth2_serde_utils"
 version = "0.1.1"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -822,7 +852,7 @@ dependencies = [
 [[package]]
 name = "eth2_ssz"
 version = "0.4.1"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "ethereum-types",
  "itertools",
@@ -831,9 +861,8 @@ dependencies = [
 
 [[package]]
 name = "eth2_ssz_derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635b86d2c941bb71e7419a571e1763d65c93e51a1bafc400352e3bef6ff59fc9"
+version = "0.3.1"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "darling",
  "proc-macro2 1.0.52",
@@ -844,8 +873,9 @@ dependencies = [
 [[package]]
 name = "eth2_ssz_types"
 version = "0.2.2"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
+ "arbitrary",
  "derivative",
  "eth2_serde_utils",
  "eth2_ssz",
@@ -859,7 +889,7 @@ dependencies = [
 [[package]]
 name = "eth2_wallet"
 version = "0.1.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "eth2_key_derivation",
  "eth2_keystore",
@@ -935,6 +965,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "arbitrary",
  "byteorder",
  "rand 0.8.5",
  "rustc-hex",
@@ -1025,26 +1056,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "hashlink"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1166,7 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1181,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "int_to_bytes"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "bytes",
 ]
@@ -1211,6 +1236,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1265,8 +1299,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
-source = "git+https://github.com/ChorusOne/rusqlite?rev=f4f95f8caf9fd53bffd0c19530be2484c644cc16#f4f95f8caf9fd53bffd0c19530be2484c644cc16"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1328,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "merkle_proof"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "eth2_hashing",
  "ethereum-types",
@@ -1515,6 +1550,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1582,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
  "crypto-mac 0.11.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.6",
+ "hmac 0.12.1",
+ "password-hash",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -1798,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1815,9 +1873,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rfc6979"
@@ -1857,16 +1915,15 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.25.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
  "bitflags",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "memchr",
  "smallvec",
 ]
 
@@ -1914,7 +1971,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 [[package]]
 name = "safe_arith"
 version = "0.1.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 
 [[package]]
 name = "salsa20"
@@ -2049,6 +2106,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,9 +2239,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "superstruct"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a99807a055ff4ff5d249bb84c80d9eabb55ca3c452187daae43fd5b51ef695"
+checksum = "75b9e5728aa1a87141cefd4e7509903fc01fa0dcb108022b1e841a67c5159fc5"
 dependencies = [
  "darling",
  "itertools",
@@ -2186,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "swap_or_not_shuffle"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "eth2_hashing",
  "ethereum-types",
@@ -2285,7 +2353,7 @@ dependencies = [
 [[package]]
 name = "test_random_derive"
 version = "0.2.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "quote 1.0.26",
  "syn 1.0.109",
@@ -2331,14 +2399,19 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "serde",
+ "time-core",
 ]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "tiny-bip39"
@@ -2403,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "tree_hash"
 version = "0.4.1"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "eth2_hashing",
  "ethereum-types",
@@ -2413,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "tree_hash_derive"
 version = "0.4.0"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
  "darling",
  "quote 1.0.26",
@@ -2429,8 +2502,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 [[package]]
 name = "types"
 version = "0.2.1"
-source = "git+https://github.com/ChorusOne/lighthouse?rev=38514c07f222ff7783834c48cf5c0a6ee7f346d0#38514c07f222ff7783834c48cf5c0a6ee7f346d0"
+source = "git+https://github.com/ChorusOne/lighthouse?rev=ef90a15aae791435a4180d7e6bc1d8e29ced6e2e#ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"
 dependencies = [
+ "arbitrary",
  "bls",
  "cached_tree_hash",
  "compare_fields",
@@ -2479,6 +2553,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
+ "arbitrary",
  "byteorder",
  "crunchy",
  "hex",
@@ -2566,12 +2641,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2822,14 +2891,50 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
 dependencies = [
+ "aes",
  "byteorder",
  "bzip2",
+ "constant_time_eq",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
- "thiserror",
+ "hmac 0.12.1",
+ "pbkdf2 0.11.0",
+ "sha1",
  "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.7+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/lib.rs"
 clap = "^2.33"
 derive_more = "0.15"
 eth2_hashing = "0.3.0"
-eth2_key_derivation = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-eth2_keystore = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-eth2_network_config = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
+eth2_key_derivation = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+eth2_keystore = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+eth2_network_config = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e" }
 eth2_ssz = "0.4.1"
-eth2_wallet = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
+eth2_wallet = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
 ethereum-types = { version = "0.14.1", optional = true }
 env_logger = "^0.6.0"
 hex = "0.4"
@@ -35,19 +35,18 @@ serde_json = "1.0"
 ssz-rs = { git = "https://github.com/ChorusOne/ssz-rs.git", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 ssz-rs-derive = { git = "https://github.com/ChorusOne/ssz-rs.git", rev = "cb08f18ca919cc1b685b861d0fa9e2daabe89737" }
 tiny-bip39 = "^0.8.0"
-tree_hash = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-types = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
+tree_hash = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+types = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
 uuid = { version = "0.8.1", features = ["v4"] }
 
 [patch.crates-io]
-eth2_hashing = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-eth2_serde_utils = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-eth2_ssz = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-eth2_ssz_types = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-tree_hash = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-tree_hash_derive = { git = "https://github.com/ChorusOne/lighthouse", rev = "38514c07f222ff7783834c48cf5c0a6ee7f346d0"}
-# Override for https://rustsec.org/advisories/RUSTSEC-2022-0090
-libsqlite3-sys = { git = "https://github.com/ChorusOne/rusqlite", rev = "f4f95f8caf9fd53bffd0c19530be2484c644cc16" }
+eth2_hashing = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+eth2_serde_utils = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+eth2_ssz = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+eth2_ssz_derive = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+eth2_ssz_types = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+tree_hash = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
+tree_hash_derive = { git = "https://github.com/ChorusOne/lighthouse", rev = "ef90a15aae791435a4180d7e6bc1d8e29ced6e2e"}
 
 [dev-dependencies]
 test-log = "^0.2"


### PR DESCRIPTION
- Update `lighthouse` zip build dependency versions (https://github.com/ChorusOne/lighthouse/commit/ef90a15aae791435a4180d7e6bc1d8e29ced6e2e) to get rid of https://github.com/ChorusOne/eth-staking-smith/security/dependabot/1
- Upgrade `lighthouse` base version to `3.5.1` to get `libsqlite3-sys` 0.25.2 --> gets rid of https://github.com/ChorusOne/eth-staking-smith/security/dependabot/3
