### PR TITLE
Migrate to Clap 4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43b18702501396fa9bcdeecd533bc85fac75150d308fc0f6800a01e6234a003"
+checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -144,19 +144,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -169,33 +160,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -348,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -366,9 +357,9 @@ checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72493ac66d5804837f480ab3766c72bdfab91a65e565fc54fa9e42db0073a8"
+checksum = "bc65048dd435533bb1baf2ed9956b9a278fbfdcf90301b39ee117f06c0199d37"
 dependencies = [
  "anstyle",
  "bstr",
@@ -380,17 +371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,7 +378,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -471,7 +451,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.68",
+ "syn 2.0.72",
  "which",
 ]
 
@@ -552,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dc83a094a71d43eeadd254b1ec2d24cb6a0bb6cadce00df51f0db594711a32"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",
@@ -573,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
  "regex-automata 0.4.7",
@@ -602,9 +582,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]
@@ -660,13 +640,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.104"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -693,7 +672,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -728,24 +707,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
-name = "colorchoice"
-version = "1.0.1"
+name = "clap_builder"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "compare_fields"
@@ -953,7 +957,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1071,7 +1075,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1084,7 +1088,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1271,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
@@ -1281,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1347,7 +1351,7 @@ dependencies = [
  "tiny-bip39",
  "tree_hash",
  "types",
- "uuid 1.9.1",
+ "uuid 1.10.0",
 ]
 
 [[package]]
@@ -1601,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1711,7 +1715,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1850,13 +1854,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
+name = "heck"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1979,9 +1980,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.29"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2107,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2153,16 +2154,16 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2181,9 +2182,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -2222,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a3633291834c4fbebf8673acbc1b04ec9d151418ff9b8e26dcd79129928758"
+checksum = "422fbc7ff2f2f5bdffeb07718e5a5324dca72b0c9293d50df4026652385e3314"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -2294,12 +2295,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2545,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown",
 ]
@@ -2595,18 +2596,18 @@ dependencies = [
 
 [[package]]
 name = "metastruct"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfbb8826226b09b05bb62a0937cf6abb16f1f7d4b746eb95a83db14aec60f06"
+checksum = "f00a5ba4a0f3453c31c397b214e1675d95b697c33763aa58add57ea833424384"
 dependencies = [
  "metastruct_macro",
 ]
 
 [[package]]
 name = "metastruct_macro"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cb4045d5677b7da537f8cb5d0730d5b6414e3cc81c61e4b50e1f0cbdc73909"
+checksum = "7c3a991d4536c933306e52f0e8ab303757185ec13a09d1f3e1cbde5a0d8410bf"
 dependencies = [
  "darling",
  "itertools",
@@ -2639,13 +2640,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2820,15 +2822,15 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -2868,7 +2870,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2974,9 +2976,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3057,7 +3059,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3108,15 +3110,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
  "difflib",
@@ -3128,15 +3133,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -3168,7 +3173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3343,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3363,9 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3732,9 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -3745,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3788,31 +3793,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -3825,7 +3831,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3900,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
+checksum = "57d79b758b7cb2085612b11a235055e485605a5103faccdd633f35bd7aee69dd"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4150,15 +4156,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -4175,7 +4181,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4224,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4274,14 +4280,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4320,7 +4327,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4333,32 +4340,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4441,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4456,31 +4454,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4519,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
@@ -4572,7 +4569,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4762,12 +4759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
-
-[[package]]
 name = "universal-hash"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4836,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
@@ -4856,16 +4847,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -4918,7 +4903,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -4952,7 +4937,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5050,7 +5035,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5068,7 +5053,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5088,18 +5082,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -5110,9 +5104,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5122,9 +5116,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5134,15 +5128,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5152,9 +5146,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5164,9 +5158,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5176,9 +5170,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5188,9 +5182,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -5232,6 +5226,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -5243,7 +5238,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5263,7 +5258,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5307,9 +5302,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.11+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "eth_staking_smith"
 path = "src/lib.rs"
 
 [dependencies]
-clap = "^2.33"
+clap = { version = "^4.5", features = ["derive"] }
 ethereum_hashing = "0.6.0"
 eth2_key_derivation = { git = "https://github.com/ChorusOne/lighthouse", rev = "1be5253610dc8fee3bf4b7a8dc1d01254bc5b57d"}
 eth2_keystore = { git = "https://github.com/ChorusOne/lighthouse", rev = "1be5253610dc8fee3bf4b7a8dc1d01254bc5b57d"}
@@ -21,13 +21,13 @@ eth2_network_config = { git = "https://github.com/ChorusOne/lighthouse", rev = "
 ethereum_ssz = "0.5.3"
 eth2_wallet = { git = "https://github.com/ChorusOne/lighthouse", rev = "1be5253610dc8fee3bf4b7a8dc1d01254bc5b57d"}
 ethereum-types = { version = "0.14.1", optional = true }
-env_logger = "^0.11.1"
+env_logger = "^0.11"
 hex = "0.4"
-lazy_static = "1.4"
+lazy_static = "1.5"
 log = "^0.4"
 getrandom = "0.2"
-regex = "1.10.3"
-serde = "1.0.196"
+regex = "1.10.6"
+serde = "1.0.204"
 serde_derive = "1.0"
 serde_json = "1.0"
 ssz_rs = { git = "https://github.com/ChorusOne/ssz-rs.git", rev = "1f94d5dfc70c86dab672e91ac46af04a5f96c342" }
@@ -36,7 +36,7 @@ tiny-bip39 = "1.0.0"
 # This must be pinned to a version that lighthouse uses
 tree_hash = "0.5.2"
 types = { git = "https://github.com/ChorusOne/lighthouse", rev = "1be5253610dc8fee3bf4b7a8dc1d01254bc5b57d"}
-uuid = { version = "1.6", features = ["v4"] }
+uuid = { version = "1.10", features = ["v4"] }
 
 [dev-dependencies]
 test-log = "^0.2"

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022, 2023 Chorus One AG
+   Copyright 2022-2024 Chorus One AG
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/deny.toml
+++ b/deny.toml
@@ -1,22 +1,7 @@
-# When outputting inclusion graphs in diagnostics that include features, this
-# option can be used to specify the depth at which feature edges will be added.
-# This option is included since the graphs can be quite large and the addition
-# of features from the crate(s) to all of the graph roots can be far too verbose.
-# This option can be overridden via `--feature-depth` on the cmd line
-feature-depth = 1
-
 [advisories]
-
-ignore = [
-    # Only used in CLI, should be fixed by https://github.com/ChorusOne/eth-staking-smith/issues/30
-    "atty@0.2.14",
-    # Unmaintained, but only used in CLI
-    "ansi_term@0.12.1"
-]
+ignore = []
 
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "allow"
 # List of explicitly allowed licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
@@ -28,8 +13,192 @@ allow = [
     "Unicode-DFS-2016",
     "BSD-3-Clause",
     "BSD-2-Clause",
-    "Zlib"
+    "Zlib",
+    "MPL-2.0",
+    "OpenSSL"
 ]
+
+#
+# Most of crates above are coming from lighthouse
+# where they keep repository license of Apache 2.0
+# https://github.com/sigp/lighthouse/blob/291146eeb4fea4bbe0aa3c6aa37eadd566d7e1d4/LICENSE 
+[[licenses.clarify]]
+crate = "merkle_proof"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+[[licenses.clarify]]
+crate = "bls"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "cached_tree_hash"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "compare_fields"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "compare_fields_derive"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "eth2_config"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "eth2_interop_keypairs"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "eth2_key_derivation"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "eth2_keystore"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "eth2_network_config"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "eth2_wallet"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "int_to_bytes"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "kzg"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "lighthouse_metrics"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "logging"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "pretty_reqwest_error"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "safe_arith"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "sensitive_url"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "swap_or_not_shuffle"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "test_random_derive"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+
+[[licenses.clarify]]
+crate = "types"
+expression = "Apache-2.0"
+license-files = [
+    { path = "../../LICENSE", hash = 0x001c7e6c },
+]
+
+[[licenses.clarify]]
+crate = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 
 #
@@ -43,3 +212,12 @@ allow = [
 deny = [
     { name = "serde_derive", version = ">1.0.171, <1.0.185" }
 ]
+
+
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1

--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -3,9 +3,10 @@ use std::path::Path;
 use eth2_network_config::Eth2NetworkConfig;
 use types::{ChainSpec, Config, MainnetEthSpec, MinimalEthSpec};
 
-use crate::DepositError;
+use crate::{networks::SupportedNetworks, DepositError};
 
-pub fn chain_spec_for_network(network_name: String) -> Result<ChainSpec, DepositError> {
+pub fn chain_spec_for_network(network: SupportedNetworks) -> Result<ChainSpec, DepositError> {
+    let network_name = network.to_string();
     if ["goerli", "prater", "mainnet", "holesky"].contains(&network_name.as_str()) {
         Ok(Eth2NetworkConfig::constant(&network_name)
             .unwrap()

--- a/src/cli/bls_to_execution_change.rs
+++ b/src/cli/bls_to_execution_change.rs
@@ -1,116 +1,67 @@
 use crate::bls_to_execution_change;
-use clap::{App, Arg, ArgMatches};
+use clap::{arg, Parser};
 
-#[allow(clippy::needless_lifetimes)]
-pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("bls-to-execution-change")
-        .about("Generates a SignedBLSToExecutionChange object which can be sent to the Beacon Node to change the withdrawal address from BLS to an execution address.")
-        .arg(
-            Arg::with_name("mnemonic")
-                .long("mnemonic")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "The mnemonic that you used to generate your
-                keys. (It is recommended not to use this
-                argument, and wait for the CLI to ask you
-                for your mnemonic as otherwise it will
-                appear in your shell history.)",
-                ),
-        )
-        .arg(
-            Arg::with_name("chain")
-                .long("chain")
-                .required(true)
-                .takes_value(true)
-                .possible_values(&["goerli", "prater", "mainnet", "holesky"])
-                .help(
-                    r#"The name of Ethereum PoS chain you are
-                targeting. Use "mainnet" if you are
-                depositing ETH"#,
-                ),
-        )
-        .arg(
-            Arg::with_name("validator_start_index")
-                .long("validator_start_index")
-                .required(false)
-                .takes_value(true)
-                .help(
-                    "The index of the first validator's keys you wish to generate the address for
-                e.g. if you generated 3 keys before (index #0, index #1, index #2) 
-                and you want to generate for the 2nd validator, 
-                the validator_start_index would be 1. 
-                If no index specified, it will be set to 0.",
-                ),
-        )
-        .arg(
-            Arg::with_name("validator_index")
-                .long("validator_index")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "On-chain index of the validator.",
-                ),
-        )
-        .arg(
-            Arg::with_name("bls_withdrawal_credentials")
-                .long("bls_withdrawal_credentials")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "BLS withdrawal credentials you used when depositing the validator.",
-                ),
-        )
-        .arg(
-            Arg::with_name("execution_address")
-                .long("execution_address")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "Execution (0x01) address to which funds withdrawn should be sent to.",
-                ),
-        )
+#[derive(Clone, Parser)]
+pub struct BlsToExecutionChangeSubcommandOpts {
+    /// The mnemonic that you used to generate your
+    /// keys.
+    ///
+    /// It is recommended not to use this
+    /// argument, and wait for the CLI to ask you
+    ///    for your mnemonic as otherwise it will
+    ///    appear in your shell history.
+    #[arg(long)]
+    pub mnemonic: String,
+
+    /// The name of Ethereum PoS chain you are targeting.
+    ///
+    /// Use "mainnet" if you are
+    /// depositing ETH
+    #[arg(value_enum, long)]
+    pub chain: crate::networks::SupportedNetworks,
+
+    /// The index of the first validator's keys you wish to generate the address for
+    /// e.g. if you generated 3 keys before (index #0, index #1, index #2)
+    /// and you want to generate for the 2nd validator,
+    /// the validator_start_index would be 1.
+    /// If no index specified, it will be set to 0.
+    #[arg(long, visible_alias = "validator_start_index")]
+    pub validator_start_index: u32,
+
+    /// On-chain beacon index of the validator.
+    #[arg(long, visible_alias = "validator_index")]
+    pub validator_index: u32,
+
+    /// BLS withdrawal credentials you used when depositing the validator.
+    #[arg(long, visible_alias = "bls_withdrawal_credentials")]
+    pub bls_withdrawal_credentials: String,
+
+    /// Execution (0x01) address to which funds withdrawn should be sent to.
+    #[arg(long, visible_alias = "execution_address")]
+    pub execution_address: String,
 }
 
-#[allow(clippy::needless_lifetimes)]
-pub fn run<'a>(sub_match: &ArgMatches<'a>) {
-    let mnemonic = sub_match.value_of("mnemonic").unwrap();
+impl BlsToExecutionChangeSubcommandOpts {
+    pub fn run(&self) {
+        let bls_to_execution_change = bls_to_execution_change::BLSToExecutionRequest::new(
+            self.mnemonic.as_bytes(),
+            self.validator_start_index,
+            self.validator_index,
+            self.execution_address.as_str(),
+        );
 
-    let chain = sub_match
-        .value_of("chain")
-        .expect("missing chain identifier");
+        let signed_bls_to_execution_change = bls_to_execution_change.sign(self.chain.clone());
 
-    let validator_start_index = sub_match
-        .value_of("validator_start_index")
-        .map(|idx| idx.parse::<u32>().expect("invalid validator index"))
-        .unwrap_or(0);
+        signed_bls_to_execution_change.clone().validate(
+            self.bls_withdrawal_credentials.as_str(),
+            self.execution_address.as_str(),
+            self.chain.clone(),
+        );
 
-    let validator_index = sub_match
-        .value_of("validator_index")
-        .map(|idx| idx.parse::<u32>().expect("invalid validator index"))
-        .unwrap_or(0);
+        let export = signed_bls_to_execution_change.export();
 
-    let execution_address = sub_match.value_of("execution_address").unwrap();
-    let bls_withdrawal_credentials = sub_match.value_of("bls_withdrawal_credentials").unwrap();
-
-    let bls_to_execution_change = bls_to_execution_change::BLSToExecutionRequest::new(
-        mnemonic.as_bytes(),
-        validator_start_index,
-        validator_index,
-        execution_address,
-    );
-
-    let signed_bls_to_execution_change = bls_to_execution_change.sign(chain);
-
-    signed_bls_to_execution_change.clone().validate(
-        bls_withdrawal_credentials,
-        execution_address,
-        chain,
-    );
-
-    let export = signed_bls_to_execution_change.export();
-
-    let signed_bls_to_execution_change_json =
-        serde_json::to_string_pretty(&export).expect("could not parse validator export");
-    println!("{}", signed_bls_to_execution_change_json);
+        let signed_bls_to_execution_change_json =
+            serde_json::to_string_pretty(&export).expect("could not parse validator export");
+        println!("{}", signed_bls_to_execution_change_json);
+    }
 }

--- a/src/cli/existing_mnemonic.rs
+++ b/src/cli/existing_mnemonic.rs
@@ -1,168 +1,109 @@
-use crate::Validators;
-use clap::{App, Arg, ArgMatches};
+use crate::{key_material::KdfVariant, networks::SupportedNetworks, Validators};
+use clap::{arg, Parser};
 
-#[allow(clippy::needless_lifetimes)]
-pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("existing-mnemonic")
-        .about("Generate (or recover) keys from an existing mnemonic.")
-        .arg(
-            Arg::with_name("mnemonic")
-                .long("mnemonic")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "The mnemonic that you used to generate your
-                keys. (It is recommended not to use this
-                argument, and wait for the CLI to ask you
-                for your mnemonic as otherwise it will
-                appear in your shell history.)",
-                ),
-        )
-        .arg(
-            Arg::with_name("num_validators")
-                .long("num_validators")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "The number of new validator keys you want to
-                generate (you can always generate more
-                later)",
-                ),
-        )
-        .arg(
-            Arg::with_name("chain")
-                .long("chain")
-                .required(false)
-                .takes_value(true)
-                .possible_values(&["goerli", "prater", "mainnet", "holesky"])
-                .help(
-                    r#"The name of Ethereum PoS chain you are
-                targeting. Use "mainnet" if you are
-                depositing ETH"#,
-                ),
-        )
-        .arg(
-            Arg::with_name("keystore_password")
-                .long("keystore_password")
-                .required(false)
-                .takes_value(true)
-                .help(
-                    "The password that will secure your
-                keystores. You will need to re-enter this to
-                decrypt them when you setup your Ethereum
-                validators. If omitted, keystores will not be generated.",
-                ),
-        )
-        .arg(
-            Arg::with_name("validator_start_index")
-                .long("validator_start_index")
-                .required(false)
-                .takes_value(true)
-                .help(
-                    "The index of the first validator's keys you wish to generate 
-                e.g. if you generated 3 keys before (index #0, index #1, index #2) 
-                and you want to regenerate starting from the 2nd validator, 
-                the validator_start_index would be 1. 
-                If no start index specified, it will be set to 0.",
-                ),
-        )
-        .arg(
-            Arg::with_name("withdrawal_credentials")
-                .long("withdrawal_credentials")
-                .required(false)
-                .takes_value(true)
-                .help(
-                    "If this field is set and valid, the given
-                value will be used to set the
-                withdrawal credentials. Otherwise, it will
-                generate withdrawal credentials with the
-                mnemonic-derived withdrawal public key. Valid formats are 
-                ^(0x[a-fA-F0-9]{40})$ for execution addresses, 
-                ^(0x01[0]{22}[a-fA-F0-9]{40})$ for execution withdrawal credentials 
-                and ^(0x00[a-fA-F0-9]{62})$ for BLS withdrawal credentials.",
-                ),
-        )
-        .arg(
-            Arg::with_name("kdf")
-                .long("kdf")
-                .required(false)
-                .takes_value(true)
-                .possible_values(&["scrypt", "pbkdf2"])
-                .help(
-                    "Use this argument to select the key derivation function for the keystores depending on your use case with `scrypt` using higher security parameters 
-                    and consequently slower performance vs `pbkdf2` achieving better performance with lower security parameters compared to `scrypt`",
-                ),
-        )
-        .arg(
-            Arg::with_name("testnet_config")
-                .long("testnet_config")
-                .required(false)
-                .takes_value(true)
-                .help("Path to a custom Eth PoS chain config")
-        )
+#[derive(Clone, Parser)]
+pub struct ExistingMnemonicSubcommandOpts {
+    /// The mnemonic that you used to generate your
+    /// keys.
+    ///
+    /// It is recommended not to use this
+    /// argument, and wait for the CLI to ask you
+    ///    for your mnemonic as otherwise it will
+    ///    appear in your shell history.
+    #[arg(long)]
+    pub mnemonic: String,
+
+    /// The name of Ethereum PoS chain you are targeting.
+    ///
+    /// Use "mainnet" if you are
+    /// depositing ETH
+    #[arg(value_enum, long)]
+    pub chain: Option<SupportedNetworks>,
+
+    /// The number of new validator keys you want to
+    /// generate.
+    ///
+    /// You can always generate more later
+    #[arg(long, visible_alias = "num_validators")]
+    pub num_validators: u32,
+
+    /// The password that will secure your keystores.
+    ///
+    /// You will need to re-enter this to
+    /// decrypt them when you setup your Ethereum
+    /// validators. If omitted, keystores will not be generated.
+    #[arg(long, visible_alias = "keystore_password")]
+    pub keystore_password: Option<String>,
+
+    /// The index of the first validator's keys you wish to generate the address for
+    // e.g. if you generated 3 keys before (index #0, index #1, index #2)
+    // and you want to generate for the 2nd validator,
+    // the validator_start_index would be 1.
+    // If no index specified, it will be set to 0.
+    #[arg(long, visible_alias = "validator_start_index")]
+    pub validator_start_index: Option<u32>,
+
+    /// If this field is set and valid, the given
+    /// value will be used to set the
+    /// withdrawal credentials. Otherwise, it will
+    /// generate withdrawal credentials with the
+    /// mnemonic-derived withdrawal public key. Valid formats are
+    /// ^(0x[a-fA-F0-9]{40})$ for execution addresses,
+    /// ^(0x01[0]{22}[a-fA-F0-9]{40})$ for execution withdrawal credentials
+    /// and ^(0x00[a-fA-F0-9]{62})$ for BLS withdrawal credentials.
+    #[arg(long, visible_alias = "withdrawal_credentials")]
+    pub withdrawal_credentials: Option<String>,
+
+    /// Use this argument to select the key derivation function for the keystores.
+    ///
+    /// Depending on your use case with `scrypt` using higher security parameters
+    /// and consequently slower performance vs `pbkdf2`,
+    /// achieving better performance with lower security parameters compared to `scrypt`
+    #[arg(long)]
+    pub kdf: Option<KdfVariant>,
+
+    /// Path to a custom Eth PoS chain config
+    #[arg(long, visible_alias = "testnet_config")]
+    pub testnet_config: Option<String>,
 }
 
-#[allow(clippy::needless_lifetimes)]
-pub fn run<'a>(sub_match: &ArgMatches<'a>) {
-    let mnemonic = sub_match.value_of("mnemonic").unwrap();
+impl ExistingMnemonicSubcommandOpts {
+    pub fn run(&self) {
+        let chain = if self.chain.is_some() && self.testnet_config.is_some() {
+            panic!("should only pass one of testnet_config or chain")
+        } else if self.testnet_config.is_some() {
+            // Signalizes custom testnet config will be used
+            None
+        } else {
+            self.chain.clone()
+        };
 
-    let num_validators = sub_match
-        .value_of("num_validators")
-        .expect("missing number of validators")
-        .parse::<u32>()
-        .expect("invalid number of validators");
+        let password = self
+            .keystore_password
+            .clone()
+            .map(|p| p.as_bytes().to_owned());
 
-    let chain = sub_match.value_of("chain");
-
-    let chain_spec_file = match chain {
-        Some(_) => None,
-        None => Some(
-            sub_match
-                .value_of("testnet_config")
-                .expect("must pass testnet config path if not using chain")
-                .to_string(),
-        ),
-    };
-
-    let chain = if chain_spec_file.is_some() && chain.is_some() {
-        panic!("should only pass one of testnet_config or chain")
-    } else if chain_spec_file.is_some() {
-        // Placeholder value
-        ""
-    } else {
-        chain.unwrap()
-    };
-
-    let keystore_password = sub_match.value_of("keystore_password");
-
-    let validator_start_index = sub_match
-        .value_of("validator_start_index")
-        .map(|idx| idx.parse::<u32>().expect("invalid validator start index"));
-
-    let withdrawal_credentials = sub_match.value_of("withdrawal_credentials");
-
-    let kdf = sub_match.value_of("kdf");
-
-    let validators = Validators::new(
-        Some(mnemonic.as_bytes()),
-        keystore_password.map(|p| p.as_bytes()),
-        Some(num_validators),
-        validator_start_index,
-        withdrawal_credentials.is_none(),
-        kdf,
-    );
-    let export: serde_json::Value = validators
-        .export(
-            chain.to_string(),
-            withdrawal_credentials,
-            32_000_000_000,
-            "2.3.0".to_string(),
-            chain_spec_file,
-        )
-        .unwrap()
-        .try_into()
-        .expect("could not serialise validator export");
-    let export_json =
-        serde_json::to_string_pretty(&export).expect("could not parse validator export");
-    println!("{}", export_json);
+        let validators = Validators::new(
+            Some(self.mnemonic.as_bytes()),
+            password,
+            Some(self.num_validators),
+            self.validator_start_index,
+            self.withdrawal_credentials.is_none(),
+            self.kdf.clone(),
+        );
+        let export: serde_json::Value = validators
+            .export(
+                chain,
+                self.withdrawal_credentials.clone(),
+                32_000_000_000,
+                "2.3.0".to_string(),
+                self.testnet_config.clone(),
+            )
+            .unwrap()
+            .try_into()
+            .expect("could not serialise validator export");
+        let export_json =
+            serde_json::to_string_pretty(&export).expect("could not parse validator export");
+        println!("{}", export_json);
+    }
 }

--- a/src/cli/new_mnemonic.rs
+++ b/src/cli/new_mnemonic.rs
@@ -1,137 +1,99 @@
-use crate::Validators;
-use clap::{App, Arg, ArgMatches};
+use crate::{key_material::KdfVariant, networks::SupportedNetworks, Validators};
+use clap::{arg, Parser};
 
-#[allow(clippy::needless_lifetimes)]
-pub fn subcommand<'a, 'b>() -> App<'a, 'b> {
-    App::new("new-mnemonic")
-        .about("Generate new keys with new mnemonic.")
-        .arg(
-            Arg::with_name("num_validators")
-                .long("num_validators")
-                .required(true)
-                .takes_value(true)
-                .help(
-                    "The number of new validator keys you want to
-                generate (you can always generate more
-                later)",
-                ),
-        )
-        .arg(
-            Arg::with_name("chain")
-                .long("chain")
-                .required(false)
-                .takes_value(true)
-                .possible_values(&["goerli", "prater", "mainnet", "holesky"])
-                .help(
-                    r#"The name of Ethereum PoS chain you are
-                targeting. Use "mainnet" if you are
-                depositing ETH"#,
-                ),
-        )
-        .arg(
-            Arg::with_name("keystore_password")
-                .long("keystore_password")
-                .required(false)
-                .takes_value(true)
-                .help(
-                    "The password that will encrypt your
-                keystores. You will need to re-enter this to
-                decrypt them when you setup your Ethereum
-                validators. If omitted, keystores will not be generated.",
-                ),
-        )
-        .arg(
-            Arg::with_name("withdrawal_credentials")
-                .long("withdrawal_credentials")
-                .required(false)
-                .takes_value(true)
-                .help(
-                    "If this field is set and valid, the given
-                value will be used to set the withdrawal credentials. 
-                Otherwise, it will generate withdrawal credentials with the
-                mnemonic-derived withdrawal public key. 
-                Valid formats are ^(0x[a-fA-F0-9]{40})$ for execution addresses, 
-                ^(0x01[0]{22}[a-fA-F0-9]{40})$ for execution withdrawal credentials
-                and ^(0x00[a-fA-F0-9]{62})$ for BLS withdrawal credentials.",
-                ),
-        )
-        .arg(
-            Arg::with_name("kdf")
-                .long("kdf")
-                .required(false)
-                .takes_value(true)
-                .possible_values(&["scrypt", "pbkdf2"])
-                .help(
-                    "Use this argument to select the key derivation function for the keystores depending on your use case with `scrypt` using higher security parameters 
-                    and consequently slower performance vs `pbkdf2` achieving better performance with lower security parameters compared to `scrypt`",
-                ),
-        )
-        .arg(
-            Arg::with_name("testnet_config")
-                .long("testnet_config")
-                .required(false)
-                .takes_value(true)
-                .help("Path to a custom Eth PoS chain config")
-        )
+#[derive(Parser, Clone)]
+pub struct NewMnemonicSubcommandOpts {
+    /// The name of Ethereum PoS chain you are targeting.
+    ///
+    /// Use "mainnet" if you are
+    /// depositing ETH
+    #[arg(value_enum, long)]
+    pub chain: Option<SupportedNetworks>,
+
+    /// The number of new validator keys you want to
+    /// generate.
+    ///
+    /// You can always generate more later
+    #[arg(long, visible_alias = "num_validators")]
+    pub num_validators: u32,
+
+    /// The password that will secure your keystores.
+    ///
+    /// You will need to re-enter this to
+    /// decrypt them when you setup your Ethereum
+    /// validators. If omitted, keystores will not be generated.
+    #[arg(long, visible_alias = "keystore_password")]
+    pub keystore_password: Option<String>,
+
+    /// The index of the first validator's keys you wish to generate the address for
+    // e.g. if you generated 3 keys before (index #0, index #1, index #2)
+    // and you want to generate for the 2nd validator,
+    // the validator_start_index would be 1.
+    // If no index specified, it will be set to 0.
+    #[arg(long, visible_alias = "validator_start_index")]
+    pub validator_start_index: Option<u32>,
+
+    /// If this field is set and valid, the given
+    /// value will be used to set the
+    /// withdrawal credentials. Otherwise, it will
+    /// generate withdrawal credentials with the
+    /// mnemonic-derived withdrawal public key. Valid formats are
+    /// ^(0x[a-fA-F0-9]{40})$ for execution addresses,
+    /// ^(0x01[0]{22}[a-fA-F0-9]{40})$ for execution withdrawal credentials
+    /// and ^(0x00[a-fA-F0-9]{62})$ for BLS withdrawal credentials.
+    #[arg(long, visible_alias = "withdrawal_credentials")]
+    pub withdrawal_credentials: Option<String>,
+
+    /// Use this argument to select the key derivation function for the keystores.
+    ///
+    /// Depending on your use case with `scrypt` using higher security parameters
+    /// and consequently slower performance vs `pbkdf2`,
+    /// achieving better performance with lower security parameters compared to `scrypt`
+    #[arg(long)]
+    pub kdf: Option<KdfVariant>,
+
+    /// Path to a custom Eth PoS chain config
+    #[arg(long, visible_alias = "testnet_config")]
+    pub testnet_config: Option<String>,
 }
 
-#[allow(clippy::needless_lifetimes)]
-pub fn run<'a>(sub_match: &ArgMatches<'a>) {
-    let num_validators_str = sub_match
-        .value_of("num_validators")
-        .expect("missing number of validators");
+impl NewMnemonicSubcommandOpts {
+    pub fn run(&self) {
+        let chain = if self.chain.is_some() && self.testnet_config.is_some() {
+            panic!("should only pass one of testnet_config or chain")
+        } else if self.testnet_config.is_some() {
+            // Signalizes custom testnet config will be used
+            None
+        } else {
+            self.chain.clone()
+        };
 
-    let num_validators = num_validators_str
-        .parse::<u32>()
-        .expect("invalid number of validators");
+        let password = self
+            .keystore_password
+            .clone()
+            .map(|p| p.as_bytes().to_owned());
 
-    let chain = sub_match.value_of("chain");
-
-    let chain_spec_file = match chain {
-        Some(_) => None,
-        None => Some(
-            sub_match
-                .value_of("testnet_config")
-                .expect("must pass testnet config path if not using chain")
-                .to_string(),
-        ),
-    };
-
-    let chain = if chain_spec_file.is_some() && chain.is_some() {
-        panic!("should only pass one of testnet_config or chain")
-    } else if chain_spec_file.is_some() {
-        // Placeholder value
-        ""
-    } else {
-        chain.unwrap()
-    };
-
-    let keystore_password = sub_match.value_of("keystore_password");
-
-    let withdrawal_credentials = sub_match.value_of("withdrawal_credentials");
-
-    let kdf = sub_match.value_of("kdf");
-
-    let validators = Validators::new(
-        None,
-        keystore_password.map(|p| p.as_bytes()),
-        Some(num_validators),
-        None,
-        withdrawal_credentials.is_none(),
-        kdf,
-    );
-    let export: serde_json::Value = validators
-        .export(
-            chain.to_string(),
-            withdrawal_credentials,
-            32_000_000_000,
-            "2.3.0".to_string(),
-            chain_spec_file,
-        )
-        .unwrap()
-        .try_into()
-        .expect("could not serialise validator export");
-    let export_json =
-        serde_json::to_string_pretty(&export).expect("could not parse validator export");
-    println!("{}", export_json);
+        let validators = Validators::new(
+            None,
+            password,
+            Some(self.num_validators),
+            None,
+            self.withdrawal_credentials.is_none(),
+            self.kdf.clone(),
+        );
+        let export: serde_json::Value = validators
+            .export(
+                chain,
+                self.withdrawal_credentials.clone(),
+                32_000_000_000,
+                "2.3.0".to_string(),
+                self.testnet_config.clone(),
+            )
+            .unwrap()
+            .try_into()
+            .expect("could not serialise validator export");
+        let export_json =
+            serde_json::to_string_pretty(&export).expect("could not parse validator export");
+        println!("{}", export_json);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
+#![forbid(unsafe_code)]
 pub mod bls_to_execution_change;
 pub mod chain_spec;
 pub mod cli;
 pub(crate) mod deposit;
 pub(crate) mod key_material;
+pub mod networks;
 pub(crate) mod seed;
 pub(crate) mod utils;
 pub mod validators;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,31 @@
-use clap::App;
+#![forbid(unsafe_code)]
+use clap::{Parser, Subcommand};
 use eth_staking_smith::cli::{bls_to_execution_change, existing_mnemonic, new_mnemonic};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Opts {
+    #[command(subcommand)]
+    subcommand: SubCommands,
+}
+
+#[derive(Subcommand)]
+enum SubCommands {
+    /// Generates a SignedBLSToExecutionChange object which can be sent
+    /// to the Beacon Node to change the withdrawal address from BLS to an execution address
+    BlsToExecutionChange(bls_to_execution_change::BlsToExecutionChangeSubcommandOpts),
+    ExistingMnemonic(existing_mnemonic::ExistingMnemonicSubcommandOpts),
+    NewMnemonic(new_mnemonic::NewMnemonicSubcommandOpts),
+}
 
 fn main() {
     env_logger::init();
-    let matches = App::new(env!("CARGO_PKG_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .author(&*format!("Chorus one <{}>", env!("CARGO_PKG_AUTHORS")))
-        .about(env!("CARGO_PKG_DESCRIPTION"))
-        .subcommand(new_mnemonic::subcommand())
-        .subcommand(existing_mnemonic::subcommand())
-        .subcommand(bls_to_execution_change::subcommand())
-        .get_matches();
 
-    match matches.subcommand() {
-        ("new-mnemonic", Some(sub_match)) => new_mnemonic::run(sub_match),
-        ("existing-mnemonic", Some(sub_match)) => existing_mnemonic::run(sub_match),
-        ("bls-to-execution-change", Some(sub_match)) => bls_to_execution_change::run(sub_match),
-        _ => println!("{}", matches.usage()),
+    let opts = Opts::parse();
+    match opts.subcommand {
+        // Server
+        SubCommands::BlsToExecutionChange(sub) => sub.run(),
+        SubCommands::ExistingMnemonic(sub) => sub.run(),
+        SubCommands::NewMnemonic(sub) => sub.run(),
     }
 }

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -1,0 +1,20 @@
+#[derive(clap::ValueEnum, Clone, Hash, Eq, PartialEq)]
+pub enum SupportedNetworks {
+    Mainnet,
+    Holesky,
+    // These are legacy networks they are supported on best effort basis
+    Prater,
+    Goerli,
+}
+
+impl std::fmt::Display for SupportedNetworks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            SupportedNetworks::Mainnet => "mainnet",
+            SupportedNetworks::Holesky => "holesky",
+            SupportedNetworks::Prater => "goerli",
+            SupportedNetworks::Goerli => "goerli",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/tests/e2e/existing_mnemonic.rs
+++ b/tests/e2e/existing_mnemonic.rs
@@ -795,7 +795,7 @@ fn test_error_unsupported_network() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg(num_validators);
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "goerliX' isn't a valid value for '--chain <chain>",
+        "invalid value \'goerliX\' for \'--chain <CHAIN>\'",
     ));
 
     Ok(())
@@ -827,7 +827,7 @@ fn test_error_unsupported_kdf() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg(unsupported_kdf);
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "pbkdf3' isn't a valid value for '--kdf <kdf>",
+        "invalid value 'pbkdf3' for '--kdf <KDF>'",
     ));
 
     Ok(())

--- a/tests/e2e/new_mnemonic.rs
+++ b/tests/e2e/new_mnemonic.rs
@@ -1,6 +1,6 @@
 use assert_cmd::prelude::*;
 use eth2_keystore::{json_keystore::JsonKeystore, Keystore};
-use eth_staking_smith::ValidatorExports;
+use eth_staking_smith::{networks::SupportedNetworks, ValidatorExports};
 use predicates::prelude::*;
 use std::{path::PathBuf, process::Command};
 
@@ -11,7 +11,7 @@ use std::{path::PathBuf, process::Command};
 */
 #[test]
 fn test_deposit_data_keystore() -> Result<(), Box<dyn std::error::Error>> {
-    let chain = "goerli";
+    let chain = SupportedNetworks::Goerli;
     let decryption_password = "testtest";
     let num_validators = "1";
 
@@ -21,7 +21,7 @@ fn test_deposit_data_keystore() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.arg("new-mnemonic");
     cmd.arg("--chain");
-    cmd.arg(chain);
+    cmd.arg(chain.to_string());
     cmd.arg("--keystore_password");
     cmd.arg(decryption_password);
     cmd.arg("--num_validators");
@@ -49,9 +49,8 @@ fn test_deposit_data_keystore() -> Result<(), Box<dyn std::error::Error>> {
         .to_owned();
     let keystore = generated_validator_json.keystores.get(0).unwrap();
 
-    generated_deposit_data.validate(
-        eth_staking_smith::chain_spec::chain_spec_for_network(chain.to_string()).unwrap(),
-    );
+    generated_deposit_data
+        .validate(eth_staking_smith::chain_spec::chain_spec_for_network(chain).unwrap());
 
     // decrypt keystore with expected password to derive private key
     let encoded_private_key = decrypt_generated_keystore(
@@ -104,7 +103,8 @@ fn test_multliple_validators() -> Result<(), Box<dyn std::error::Error>> {
     let generated_private_keys = generated_validator_json.private_keys;
     let generated_deposit_datas = generated_validator_json.deposit_data;
 
-    let spec = eth_staking_smith::chain_spec::chain_spec_for_network("goerli".to_string()).unwrap();
+    let spec =
+        eth_staking_smith::chain_spec::chain_spec_for_network(SupportedNetworks::Goerli).unwrap();
 
     for deposit_data in generated_deposit_datas {
         deposit_data.validate(spec.clone());
@@ -135,7 +135,7 @@ fn test_multliple_validators() -> Result<(), Box<dyn std::error::Error>> {
 */
 #[test]
 fn test_withdrawal_address_execution() -> Result<(), Box<dyn std::error::Error>> {
-    let chain = "goerli";
+    let chain = SupportedNetworks::Goerli;
     let decryption_password = "testtest";
     let num_validators = "1";
     let execution_withdrawal_credentials = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
@@ -146,7 +146,7 @@ fn test_withdrawal_address_execution() -> Result<(), Box<dyn std::error::Error>>
 
     cmd.arg("new-mnemonic");
     cmd.arg("--chain");
-    cmd.arg(chain);
+    cmd.arg(chain.to_string());
     cmd.arg("--keystore_password");
     cmd.arg(decryption_password);
     cmd.arg("--num_validators");
@@ -175,9 +175,8 @@ fn test_withdrawal_address_execution() -> Result<(), Box<dyn std::error::Error>>
         .expect("could not get generated private key")
         .to_owned();
 
-    generated_deposit_data.validate(
-        eth_staking_smith::chain_spec::chain_spec_for_network(chain.to_string()).unwrap(),
-    );
+    generated_deposit_data
+        .validate(eth_staking_smith::chain_spec::chain_spec_for_network(chain).unwrap());
 
     // decrypt keystore with expected password to derive private key
     let encoded_private_key = decrypt_generated_keystore(
@@ -194,7 +193,7 @@ fn test_withdrawal_address_execution() -> Result<(), Box<dyn std::error::Error>>
 */
 #[test]
 fn test_withdrawal_credentials_bls() -> Result<(), Box<dyn std::error::Error>> {
-    let chain = "goerli";
+    let chain = SupportedNetworks::Goerli;
     let decryption_password = "testtest";
     let num_validators = "3";
     let bls_withdrawal_credentials =
@@ -205,7 +204,7 @@ fn test_withdrawal_credentials_bls() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.arg("new-mnemonic");
     cmd.arg("--chain");
-    cmd.arg(chain);
+    cmd.arg(chain.to_string());
     cmd.arg("--keystore_password");
     cmd.arg(decryption_password);
     cmd.arg("--num_validators");
@@ -234,9 +233,8 @@ fn test_withdrawal_credentials_bls() -> Result<(), Box<dyn std::error::Error>> {
         .expect("could not get generated private key")
         .to_owned();
 
-    generated_deposit_data.validate(
-        eth_staking_smith::chain_spec::chain_spec_for_network(chain.to_string()).unwrap(),
-    );
+    generated_deposit_data
+        .validate(eth_staking_smith::chain_spec::chain_spec_for_network(chain).unwrap());
 
     // decrypt keystore with expected password to derive private key
     let encoded_private_key = decrypt_generated_keystore(
@@ -315,7 +313,7 @@ fn test_new_custom_testnet_config() -> Result<(), Box<dyn std::error::Error>> {
 */
 #[test]
 fn test_withdrawal_credentials_execution() -> Result<(), Box<dyn std::error::Error>> {
-    let chain = "goerli";
+    let chain = SupportedNetworks::Goerli;
     let decryption_password = "testtest";
     let num_validators = "3";
     let execution_withdrawal_credentials =
@@ -327,7 +325,7 @@ fn test_withdrawal_credentials_execution() -> Result<(), Box<dyn std::error::Err
 
     cmd.arg("new-mnemonic");
     cmd.arg("--chain");
-    cmd.arg(chain);
+    cmd.arg(chain.to_string());
     cmd.arg("--keystore_password");
     cmd.arg(decryption_password);
     cmd.arg("--num_validators");
@@ -356,9 +354,8 @@ fn test_withdrawal_credentials_execution() -> Result<(), Box<dyn std::error::Err
         .expect("could not get generated deposit data")
         .to_owned();
 
-    generated_deposit_data.validate(
-        eth_staking_smith::chain_spec::chain_spec_for_network(chain.to_string()).unwrap(),
-    );
+    generated_deposit_data
+        .validate(eth_staking_smith::chain_spec::chain_spec_for_network(chain).unwrap());
 
     // decrypt keystore with expected password to derive private key
     let encoded_private_key = decrypt_generated_keystore(
@@ -375,7 +372,7 @@ fn test_withdrawal_credentials_execution() -> Result<(), Box<dyn std::error::Err
 */
 #[test]
 fn test_keystore_kdf_pbkdf2() -> Result<(), Box<dyn std::error::Error>> {
-    let chain = "goerli";
+    let chain = SupportedNetworks::Goerli;
     let decryption_password = "testtest";
     let num_validators = "1";
     let kdf = "pbkdf2";
@@ -386,7 +383,7 @@ fn test_keystore_kdf_pbkdf2() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.arg("new-mnemonic");
     cmd.arg("--chain");
-    cmd.arg(chain);
+    cmd.arg(chain.to_string());
     cmd.arg("--keystore_password");
     cmd.arg(decryption_password);
     cmd.arg("--num_validators");
@@ -416,9 +413,8 @@ fn test_keystore_kdf_pbkdf2() -> Result<(), Box<dyn std::error::Error>> {
         .to_owned();
     let keystore = generated_validator_json.keystores.get(0).unwrap();
 
-    generated_deposit_data.validate(
-        eth_staking_smith::chain_spec::chain_spec_for_network(chain.to_string()).unwrap(),
-    );
+    generated_deposit_data
+        .validate(eth_staking_smith::chain_spec::chain_spec_for_network(chain).unwrap());
 
     // decrypt keystore with expected password to derive private key
     let encoded_private_key = decrypt_generated_keystore(
@@ -438,7 +434,7 @@ fn test_keystore_kdf_pbkdf2() -> Result<(), Box<dyn std::error::Error>> {
 */
 #[test]
 fn test_keystore_kdf_scrypt() -> Result<(), Box<dyn std::error::Error>> {
-    let chain = "goerli";
+    let chain = SupportedNetworks::Goerli;
     let decryption_password = "testtest";
     let num_validators = "1";
     let kdf = "scrypt";
@@ -449,7 +445,7 @@ fn test_keystore_kdf_scrypt() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.arg("new-mnemonic");
     cmd.arg("--chain");
-    cmd.arg(chain);
+    cmd.arg(chain.to_string());
     cmd.arg("--keystore_password");
     cmd.arg(decryption_password);
     cmd.arg("--num_validators");
@@ -479,9 +475,8 @@ fn test_keystore_kdf_scrypt() -> Result<(), Box<dyn std::error::Error>> {
         .to_owned();
     let keystore = generated_validator_json.keystores.get(0).unwrap();
 
-    generated_deposit_data.validate(
-        eth_staking_smith::chain_spec::chain_spec_for_network(chain.to_string()).unwrap(),
-    );
+    generated_deposit_data
+        .validate(eth_staking_smith::chain_spec::chain_spec_for_network(chain).unwrap());
 
     // decrypt keystore with expected password to derive private key
     let encoded_private_key = decrypt_generated_keystore(
@@ -552,7 +547,7 @@ fn test_error_unsupported_network() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg(num_validators);
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "goerliX' isn't a valid value for '--chain <chain>",
+        "invalid value \'goerliX\' for \'--chain <CHAIN>\'",
     ));
 
     Ok(())
@@ -581,7 +576,7 @@ fn test_error_unsupported_kdf() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg(unsupported_kdf);
 
     cmd.assert().failure().stderr(predicate::str::contains(
-        "pbkdf3' isn't a valid value for '--kdf <kdf>",
+        "invalid value 'pbkdf3' for '--kdf <KDF>'",
     ));
 
     Ok(())


### PR DESCRIPTION
This upgrades Clap, allowing for easier implementation of more UX changes for the CLI.

- Upgrade Clap and CLI modules using it
- Upgrade some auxiliary packages
- Migrate some magic string based logic to enums
- Upgrade `cargo-deny` to a version that disallows unlicensed
- Explicitly forbid unsafe code