### PR TITLE
Add support for generating presigned exit message from private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ Use `eth-staking-smith` via command line like:
 
 Note that --validator-beacon-index and --validator-seed-index are two distinct parameter, the former being index of validator on Beacon chain, and the latter is the index of validator private key derived from the seed
 
+It is also possible to directly pass private key with `--private-key` parameter instead,
+then `--mnemonic` and `--validator-seed-index` may be omitted like follows
+
+```
+./target/debug/eth-staking-smith presigned-exit-message --chain mainnet --private-key "0x3f3e0a69a6a66aeaec606a2ccb47c703afb2e8ae64f70a1650c03343b06e8f0c" --validator_beacon_index 100 --epoch 300000
+```
+
+
 
 ### Command to send VoluntaryExitMessage request to Beacon node
 

--- a/src/cli/presigned_exit_message.rs
+++ b/src/cli/presigned_exit_message.rs
@@ -101,7 +101,7 @@ impl PresignedExitMessageSubcommandOpts {
             let secret_key_str = self.private_key.clone().unwrap();
             let secret_key_bytes =
                 hex::decode(secret_key_str.strip_prefix("0x").unwrap_or(&secret_key_str))
-                    .expect("Invalid custom genesis validators root");
+                    .expect("Invalid private key hex input");
             voluntary_exit::voluntary_exit_message_from_secret_key(
                 secret_key_bytes.as_slice(),
                 self.validator_beacon_index as u64,

--- a/src/key_material.rs
+++ b/src/key_material.rs
@@ -4,7 +4,7 @@ use eth2_keystore::{
     json_keystore::Kdf, keypair_from_secret, Keystore, KeystoreBuilder, PlainText,
 };
 use eth2_wallet::{KeyType, ValidatorPath};
-use types::Keypair;
+use types::{Keypair, SecretKey};
 
 use crate::utils::{pbkdf2, scrypt};
 
@@ -15,6 +15,22 @@ pub struct VotingKeyMaterial {
     pub keypair: Keypair,
     pub voting_secret: PlainText,
     pub withdrawal_keypair: Option<Keypair>,
+}
+
+impl VotingKeyMaterial {
+    pub fn from_voting_secret_bytes(voting_secret_bytes: &[u8]) -> Self {
+        let sk = SecretKey::deserialize(voting_secret_bytes).expect("Invalid private key passed");
+        let pk = sk.public_key();
+        let keypair = Keypair::from_components(pk, sk);
+        let voting_secret = voting_secret_bytes.to_vec().into();
+
+        Self {
+            keypair,
+            voting_secret,
+            keystore: None,
+            withdrawal_keypair: None,
+        }
+    }
 }
 
 /// Key derivation function for the keystore

--- a/src/voluntary_exit/mod.rs
+++ b/src/voluntary_exit/mod.rs
@@ -33,5 +33,20 @@ pub fn voluntary_exit_message_from_mnemonic(
     (voluntary_exit, key_material.clone())
 }
 
+pub fn voluntary_exit_message_from_secret_key(
+    secret_key_bytes: &[u8],
+    validator_beacon_index: u64,
+    epoch: u64,
+) -> (VoluntaryExit, VotingKeyMaterial) {
+    let key_material = VotingKeyMaterial::from_voting_secret_bytes(secret_key_bytes);
+
+    let voluntary_exit = VoluntaryExit {
+        epoch: Epoch::from(epoch),
+        validator_index: validator_beacon_index,
+    };
+
+    (voluntary_exit, key_material)
+}
+
 #[cfg(test)]
 mod test;

--- a/tests/e2e/presigned_exit_message.rs
+++ b/tests/e2e/presigned_exit_message.rs
@@ -149,3 +149,37 @@ fn test_presigned_exit_message_send_beacon_node() -> Result<(), Box<dyn std::err
 
     Ok(())
 }
+
+#[test]
+fn test_presigned_exit_message_private_key() -> Result<(), Box<dyn std::error::Error>> {
+    let chain = "mainnet";
+    let private_key = "0x6d446ca271eb229044b9039354ecdfa6244d1a11615ec1a46fc82a800367de5d";
+    let validator_index = "100";
+    let epoch = "305658";
+
+    // run eth-staking-smith
+    let mut cmd = Command::cargo_bin("eth-staking-smith")?;
+
+    cmd.arg("presigned-exit-message");
+    cmd.arg("--chain");
+    cmd.arg(chain);
+    cmd.arg("--validator_beacon_index");
+    cmd.arg(validator_index);
+    cmd.arg("--private-key");
+    cmd.arg(private_key);
+    cmd.arg("--epoch");
+    cmd.arg(epoch);
+
+    cmd.assert().success();
+
+    let output = &cmd.output()?.stdout;
+    let command_output = std::str::from_utf8(output)?;
+
+    let signed_voluntary_exit: SignedVoluntaryExit = serde_json::from_str(command_output)?;
+    assert_eq!(
+        signed_voluntary_exit.signature.to_string(),
+        "0xa74f22d26da9934c2a9c783799fb9e7bef49b3d7c3759a0683b52ee5d71516c0ecdbcc47703f11959c5e701a6c47194410bed800217bd4dd0dab1e0587b14551771accd04ff1c78302f9605f44c3894976c5b3537b70cb7ac9dcb5398dc22079"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
In some setups, it might be preferred to generate exit message from private key and not mnemonic.

Patch adds new parameter `--private-key`, which can be used instead of `--mnemonic` and `--validator-seed-index` to generate presigned exit message.