### PR TITLE
Add release build for linux that uses older glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,12 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.target.runner }}
     strategy:
       matrix:
         target:
-          - { triple: x86_64-unknown-linux-gnu, suffix: linux_amd64, file: eth-staking-smith }
+          - { triple: x86_64-unknown-linux-gnu, suffix: linux_amd64, file: eth-staking-smith, runner: ubuntu-latest }
+          - { triple: x86_64-unknown-linux-gnu, suffix: linux_amd64_glibc2.31, file: eth-staking-smith, runner: ubuntu-20.04 }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
When trying to run `eth-staking-smith` on older linux (like Ubuntu 20.04 or Debian Bullseye), following error pops up:

```
./eth-staking-smith: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./eth-staking-smith)
```

This adds release build on older Ubuntu which will use older glibc