### PR TITLE
Generate presigned exit messages in a batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test",
  "test-log",
  "tiny-bip39",
  "tree_hash",
@@ -3955,6 +3956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d25269dd3a12467afe2e510f69fb0b46b698e5afb296b59f2145259deaf8e8"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3990,6 +4000,12 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
 
 [[package]]
 name = "sec1"
@@ -4119,6 +4135,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ pretty_assertions = "^1.4"
 assert_cmd = "2.0"
 predicates = "3.0"
 httpmock = "0.7"
+serial_test = "*"
 
 [[test]]
 name = "e2e-tests"

--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ then `--mnemonic` and `--validator-seed-index` may be omitted like follows
 Notice `--beacon-node-uri` parameter which makes payload to be sent to beacon node
 
 
+### Command to generate batch of presigned exit messages exit message
+
+Sometimes it may be desirable to generate batch of presigned exit messages for the
+validators created from the same mnemonic.
+
+```
+./target/debug/eth-staking-smith batch-presigned-exit-message --chain=mainnet --mnemonic='ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say' --epoch 305658  --seed-beacon-mapping='0:100,2:200'
+```
+
+Instead of accepting single `--validator-seed-index` and `--validator-beacon-index` pair of parameter,
+it takes comma-separated mapping of validator seed index to validator beacon index in `--seed-beacon-mapping`
+parameter. Keys and values in mapping should be separated by colon, so mapping of `0:100,2:200`
+will read as follows
+
+- validator with seed index `0` with given mnemonic has index `100` on beacon chain
+- validator with seed index `1` has beacon index `200`
+
 ## Exporting CLI standard output into common keystores folder format
 
 Most validator clients recognize the keystore folder format,

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ export MNEMONIC="entire habit bottom mention spoil clown finger wheat motion fox
 ./target/debug/eth-staking-smith existing-mnemonic --chain mainnet --keystore_password testtest --num_validators 1 --withdrawal_credentials "0x0100000000000000000000000000000000000000000000000000000000000001"
 ```
 
-Or, it makes possible possible to have bash prompt for mnemonic with hidden input like follows
+Or, it makes possible to have bash prompt for mnemonic with hidden input like follows
 
 ```
 echo "Please enter your mnemonic" ; read -s MNEMONIC ; export MNEMONIC
@@ -155,7 +155,7 @@ then `--mnemonic` and `--validator-seed-index` may be omitted like follows
 Notice `--beacon-node-uri` parameter which makes payload to be sent to beacon node
 
 
-### Command to generate batch of presigned exit messages exit message
+### Command to generate batch of presigned exit messages
 
 Sometimes it may be desirable to generate batch of presigned exit messages for the
 validators created from the same mnemonic.

--- a/README.md
+++ b/README.md
@@ -48,14 +48,37 @@ Regenerate key and deposit data with existing mnemonic:
 
 ### Example command:
 
-with mnemonic in plain text:
 ```
 ./target/debug/eth-staking-smith existing-mnemonic --chain mainnet --keystore_password testtest --mnemonic "entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup" --num_validators 1 --withdrawal_credentials "0x0100000000000000000000000000000000000000000000000000000000000001"
 ```
-or with mnemonic as an environment variable `MNEMONIC`:
+
+
+## Passing mnemonic as environment variable
+
+It is not always desirable to pass mnemonic as CLI argument, because
+it can be either mistakenly recorded in shell history or recorded by
+the monitoring software that could be logging process arguments on host.
+
+This is why all commands that accept `--mnemonic` argument also support
+taking mnemonic as environment variable `MNEMONIC`
+
+For example, `existing-mnemonic` command works like follows with mnemonic in plain text:
+```
+./target/debug/eth-staking-smith existing-mnemonic --chain mainnet --keystore_password testtest --mnemonic "entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup" --num_validators 1 --withdrawal_credentials "0x0100000000000000000000000000000000000000000000000000000000000001"
+```
+
+And, as follows with mnemonic as an environment variable `MNEMONIC`:
 
 ```
 export MNEMONIC="entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup"
+./target/debug/eth-staking-smith existing-mnemonic --chain mainnet --keystore_password testtest --num_validators 1 --withdrawal_credentials "0x0100000000000000000000000000000000000000000000000000000000000001"
+```
+
+Or, it makes possible possible to have bash prompt for mnemonic with hidden input like follows
+
+```
+echo "Please enter your mnemonic" ; read -s MNEMONIC ; export MNEMONIC
+Please enter your mnemonic
 ./target/debug/eth-staking-smith existing-mnemonic --chain mainnet --keystore_password testtest --num_validators 1 --withdrawal_credentials "0x0100000000000000000000000000000000000000000000000000000000000001"
 ```
 
@@ -121,8 +144,6 @@ then `--mnemonic` and `--validator-seed-index` may be omitted like follows
 ```
 ./target/debug/eth-staking-smith presigned-exit-message --chain mainnet --private-key "0x3f3e0a69a6a66aeaec606a2ccb47c703afb2e8ae64f70a1650c03343b06e8f0c" --validator_beacon_index 100 --epoch 300000
 ```
-
-
 
 ### Command to send VoluntaryExitMessage request to Beacon node
 

--- a/src/cli/batch_presigned_exit_message.rs
+++ b/src/cli/batch_presigned_exit_message.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+
+use clap::{arg, Parser};
+
+use crate::beacon_node::BeaconNodeExportable;
+use crate::voluntary_exit::operations::SignedVoluntaryExitValidator;
+use crate::{chain_spec::validators_root_and_spec, voluntary_exit};
+
+#[derive(Clone, Parser)]
+pub struct BatchPresignedExitMessageSubcommandOpts {
+    /// The mnemonic that you used to generate your
+    /// keys.
+    ///
+    /// It is recommended not to use this
+    /// argument, and wait for the CLI to ask you
+    ///    for your mnemonic as otherwise it will
+    ///    appear in your shell history.
+    #[arg(long)]
+    pub mnemonic: String,
+
+    /// The name of Ethereum PoS chain you are targeting.
+    ///
+    /// Use "mainnet" if you are
+    /// depositing ETH
+    #[arg(value_enum, long)]
+    pub chain: Option<crate::networks::SupportedNetworks>,
+
+    /// This is comma separated mapping of validator seed index to
+    /// validator beacon chain index. For example, to generate exit messages
+    /// for a validators with seed indices 0 and 1, and beacon chain indices
+    /// 111356 and 111358, pass "0:111356,1:111358" to this command.
+    #[arg(long, visible_alias = "seed_beacon_mapping")]
+    pub seed_beacon_mapping: String,
+
+    /// Epoch number which must be included in the presigned exit message.
+    #[arg(long)]
+    pub epoch: u64,
+
+    /// Path to a custom Eth PoS chain config
+    #[arg(long, visible_alias = "testnet_config")]
+    pub testnet_config: Option<String>,
+
+    /// Custom genesis validators root for the custom testnet, passed as hex string.
+    /// See https://eth2book.info/capella/part3/containers/state/ for value
+    /// description
+    #[arg(long, visible_alias = "genesis_validators_root")]
+    pub genesis_validators_root: Option<String>,
+}
+
+impl BatchPresignedExitMessageSubcommandOpts {
+    pub fn run(&self) {
+        let chain = if self.chain.is_some() && self.testnet_config.is_some() {
+            panic!("should only pass one of testnet_config or chain")
+        } else if self.testnet_config.is_some() {
+            // Signalizes custom testnet config will be used
+            None
+        } else {
+            self.chain.clone()
+        };
+
+        let (genesis_validators_root, spec) = validators_root_and_spec(
+            chain.clone(),
+            if chain.is_some() {
+                None
+            } else {
+                Some((
+                    self.genesis_validators_root
+                        .clone()
+                        .expect("Genesis validators root parameter must be set"),
+                    self.testnet_config
+                        .clone()
+                        .expect("Testnet config must be set"),
+                ))
+            },
+        );
+
+        let mut seed_beacon_mapping: HashMap<u32, u32> = HashMap::new();
+
+        for seed_beacon_pair in self.seed_beacon_mapping.split(",") {
+            let seed_beacon_pair_split = seed_beacon_pair.split(":");
+            let seed_beacon_pair_vec: Vec<u32> = seed_beacon_pair_split.map(|s| s.parse().unwrap_or_else(|e| {
+                panic!("Invalid seed to beacon mapping part, not parse-able as integer: {s}: {e:?}");
+            })).collect();
+            if seed_beacon_pair_vec.len() != 2 {
+                panic!("Every mapping in seed beacon pair split must have only one seed index and beacon index")
+            }
+            seed_beacon_mapping.insert(
+                *seed_beacon_pair_vec.first().unwrap(),
+                *seed_beacon_pair_vec.get(1).unwrap(),
+            );
+        }
+
+        let (voluntary_exits, key_materials) =
+            voluntary_exit::voluntary_exit_message_batch_from_mnemonic(
+                self.mnemonic.as_bytes(),
+                seed_beacon_mapping,
+                self.epoch,
+            );
+
+        let mut signed_voluntary_exits = vec![];
+
+        for (idx, voluntary_exit) in voluntary_exits.into_iter().enumerate() {
+            let key_material = key_materials.get(idx).unwrap();
+            let signed_voluntary_exit =
+                voluntary_exit.sign(&key_material.keypair.sk, genesis_validators_root, &spec);
+            signed_voluntary_exit.clone().validate(
+                &key_material.keypair.pk,
+                &spec,
+                &genesis_validators_root,
+            );
+            signed_voluntary_exits.push(signed_voluntary_exit.export());
+        }
+        let presigned_exit_message_batch_json =
+            serde_json::to_string_pretty(&signed_voluntary_exits)
+                .expect("could not parse validator export");
+        println!("{}", presigned_exit_message_batch_json);
+    }
+}

--- a/src/cli/batch_presigned_exit_message.rs
+++ b/src/cli/batch_presigned_exit_message.rs
@@ -11,11 +11,12 @@ pub struct BatchPresignedExitMessageSubcommandOpts {
     /// The mnemonic that you used to generate your
     /// keys.
     ///
-    /// It is recommended not to use this
-    /// argument, and wait for the CLI to ask you
-    ///    for your mnemonic as otherwise it will
-    ///    appear in your shell history.
-    #[arg(long)]
+    /// This can be provided in two ways:
+    ///
+    /// 1. Through the MNEMONIC environment variable (recommended)
+    ///
+    /// 2. Through the --mnemonic argument in plain text.
+    #[arg(long, env = "MNEMONIC")]
     pub mnemonic: String,
 
     /// The name of Ethereum PoS chain you are targeting.

--- a/src/cli/bls_to_execution_change.rs
+++ b/src/cli/bls_to_execution_change.rs
@@ -8,11 +8,12 @@ pub struct BlsToExecutionChangeSubcommandOpts {
     /// The mnemonic that you used to generate your
     /// keys.
     ///
-    /// It is recommended not to use this
-    /// argument, and wait for the CLI to ask you
-    ///    for your mnemonic as otherwise it will
-    ///    appear in your shell history.
-    #[arg(long)]
+    /// This can be provided in two ways:
+    ///
+    /// 1. Through the MNEMONIC environment variable (recommended)
+    ///
+    /// 2. Through the --mnemonic argument in plain text.
+    #[arg(long, env = "MNEMONIC")]
     pub mnemonic: String,
 
     /// The name of Ethereum PoS chain you are targeting.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch_presigned_exit_message;
 pub mod bls_to_execution_change;
 pub mod existing_mnemonic;
 pub mod new_mnemonic;

--- a/src/cli/presigned_exit_message.rs
+++ b/src/cli/presigned_exit_message.rs
@@ -9,11 +9,12 @@ pub struct PresignedExitMessageSubcommandOpts {
     /// The mnemonic that you used to generate your
     /// keys.
     ///
-    /// It is recommended not to use this
-    /// argument, and wait for the CLI to ask you
-    ///    for your mnemonic as otherwise it will
-    ///    appear in your shell history.
-    #[arg(long, required_unless_present = "private_key")]
+    /// This can be provided in two ways:
+    ///
+    /// 1. Through the MNEMONIC environment variable (recommended)
+    ///
+    /// 2. Through the --mnemonic argument in plain text.
+    #[arg(long, required_unless_present = "private_key", env = "MNEMONIC")]
     pub mnemonic: Option<String>,
 
     /// The name of Ethereum PoS chain you are targeting.

--- a/src/cli/presigned_exit_message.rs
+++ b/src/cli/presigned_exit_message.rs
@@ -44,7 +44,7 @@ pub struct PresignedExitMessageSubcommandOpts {
     pub validator_beacon_index: u32,
 
     /// Epoch number which must be included in the presigned exit message.
-    #[arg(long, visible_alias = "execution_address")]
+    #[arg(long)]
     pub epoch: u64,
 
     /// Path to a custom Eth PoS chain config

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 #![forbid(unsafe_code)]
 use clap::{Parser, Subcommand};
 use eth_staking_smith::cli::{
-    bls_to_execution_change, existing_mnemonic, new_mnemonic, presigned_exit_message,
+    batch_presigned_exit_message, bls_to_execution_change, existing_mnemonic, new_mnemonic,
+    presigned_exit_message,
 };
 
 #[derive(Parser)]
@@ -23,6 +24,10 @@ enum SubCommands {
     /// Generate presigned exit message which can be sent
     /// to the Beacon Node to start voluntary exit process for the validator
     PresignedExitMessage(presigned_exit_message::PresignedExitMessageSubcommandOpts),
+    /// Generate multiple persigned exit messages from the same mnemonic
+    BatchPresignedExitMessage(
+        batch_presigned_exit_message::BatchPresignedExitMessageSubcommandOpts,
+    ),
 }
 
 impl SubCommands {
@@ -32,6 +37,7 @@ impl SubCommands {
             Self::ExistingMnemonic(sub) => sub.run(),
             Self::NewMnemonic(sub) => sub.run(),
             Self::PresignedExitMessage(sub) => sub.run(),
+            Self::BatchPresignedExitMessage(sub) => sub.run(),
         }
     }
 }

--- a/tests/e2e/batch_presigned_exit_message.rs
+++ b/tests/e2e/batch_presigned_exit_message.rs
@@ -10,10 +10,6 @@ Command sequence to verify signature:
        --chain mainnet \
        --num_validators 3 \
        --mnemonic 'ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say'
-./target/debug/eth-staking-smith existing-mnemonic \
-       --chain mainnet \
-       --num_validators 3 \
-       --mnemonic 'ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say'
 {
   "deposit_data": [
     {
@@ -77,7 +73,7 @@ Command sequence to verify signature:
     "epoch": "305658",
     "validator_index": "200"
   },
-  "signature": "0x8db88aabdd8f03cebba47cf3df7dd5e06ab9a49f57fc209a00cb73c5ecdea192b6ab0c5965ad8e7b6b63b9d397be3df40ea84150f2ed13ca9e0ba382c24f583ca921ff0364f18e51444838992d628623598c7c12122ff46d
+  "signature": "0x8db88aabdd8f03cebba47cf3df7dd5e06ab9a49f57fc209a00cb73c5ecdea192b6ab0c5965ad8e7b6b63b9d397be3df40ea84150f2ed13ca9e0ba382c24f583ca921ff0364f18e51444838992d628623598c7c12122ff46da795c000ae15dd65"
 }
 
 cat offline-preparation.json

--- a/tests/e2e/batch_presigned_exit_message.rs
+++ b/tests/e2e/batch_presigned_exit_message.rs
@@ -1,0 +1,155 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+use types::SignedVoluntaryExit;
+
+/**
+
+Command sequence to verify signature:
+
+./target/debug/eth-staking-smith existing-mnemonic \
+       --chain mainnet \
+       --num_validators 3 \
+       --mnemonic 'ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say'
+./target/debug/eth-staking-smith existing-mnemonic \
+       --chain mainnet \
+       --num_validators 3 \
+       --mnemonic 'ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say'
+{
+  "deposit_data": [
+    {
+      "amount": 32000000000,
+      "deposit_cli_version": "2.7.0",
+      "deposit_data_root": "7ac103cb959b55dff155f7406393c3e6f1ba0011baee2b61bca00fdc3b2cb2c2",
+      "deposit_message_root": "bfd9d2c616eb570ad3fd4d4caf169b88f80490d8923537474bf1f6c5cec5e56d",
+      "fork_version": "00000000",
+      "network_name": "mainnet",
+      "pubkey": "8844cebb34d10e0e57f3c29ada375dafe14762ab85b2e408c3d6d55ce6d03317660bca9f2c2d17d8fbe14a2529ada1ea",
+      "signature": "96ebebf92967a2b187e031062f5cb5128a2bfc42559bd9dfdd1e481a056b3ef2cfddf1a0381530286013e3893e097b02129113e62a94bedd250253eb766f010824d0be7616f51b9f7609972695231bcda1cabf7a6a2d60a07e14237f2b6096ab",
+      "withdrawal_credentials": "0045b91b2f60b88e7392d49ae1364b55e713d06f30e563f9f99e10994b26221d"
+    },
+    {
+      "amount": 32000000000,
+      "deposit_cli_version": "2.7.0",
+      "deposit_data_root": "21e499c8fe06ec48b410c9c8a05c65856a6f8a0059da638e959008c3a98a8863",
+      "deposit_message_root": "c17da3de7a90e706f6299b35fd958c1c6cf47138073fa7d704405a7dea37e760",
+      "fork_version": "00000000",
+      "network_name": "mainnet",
+      "pubkey": "8b9fc0882dc9257619f973fd7034d70f4fbdf7148600e7decb4ffc74536720e4fcb0853f855bd818bb881ca219682477",
+      "signature": "b788c42fc128e92baf5f0347acba0b0608e6aa3c36a94ce8845afd8d557503ef418230d7a576b92c633c99ef9a44f27a05156c1166aec7e28487bdad98b574911b0f9848de8d881a062773e8f75b1ebdea86e6af9279ba7c62fb2f078e8e8f30",
+      "withdrawal_credentials": "006ab1394ad6a99cd25e2f1f15da057cfde5025b066bcecc1afedc2a4cb36314"
+    },
+    {
+      "amount": 32000000000,
+      "deposit_cli_version": "2.7.0",
+      "deposit_data_root": "dd07496493d9bc8d239c589ccb0e0c51a03a23934565629053b11806418fbbdb",
+      "deposit_message_root": "7c86984887d258b74f446154ab40d0e83329309c15b824bd67420225a63d6ae4",
+      "fork_version": "00000000",
+      "network_name": "mainnet",
+      "pubkey": "a15cc019cf4ce59f587d24bd58ae6011c8b638770c3c133cc9f081e161e7db01c92611f1a566b00208dd1e709f6ec716",
+      "signature": "b6312a2a9fc8427391d69e94b2d6c77db0bf78e3b1ffe368c833d1abf9f6e73e00b98d22e311fe44f7f012aa857339d715b5bbde6b28c76af3fff64f951b9a413e94a0d3729d358037bbfabd6b1905be503a91d8b19cb4fa912e2e7ddeaf044d",
+      "withdrawal_credentials": "0020e45be0f34aa53665c8f8d98b60163c9ba0b0549199172bb1a7c6f544f061"
+    }
+  ],
+  "keystores": [],
+  "mnemonic": {
+    "seed": "ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say"
+  },
+  "private_keys": [
+    "6d446ca271eb229044b9039354ecdfa6244d1a11615ec1a46fc82a800367de5d",
+    "17432f01cff4c21d848183909a300a776a57f75827414a853a52f0cbdb212f7e",
+    "338cc9dd5d27a9385e79487f597a72250e0f4fd2d6271ea012b8520b5455fc49"
+  ]
+}
+
+./ethdo validator exit --epoch 305658 --private-key=0x6d446ca271eb229044b9039354ecdfa6244d1a11615ec1a46fc82a800367de5d --offline --json | jq
+{
+  "message": {
+    "epoch": "305658",
+    "validator_index": "100"
+  },
+  "signature": "0xa74f22d26da9934c2a9c783799fb9e7bef49b3d7c3759a0683b52ee5d71516c0ecdbcc47703f11959c5e701a6c47194410bed800217bd4dd0dab1e0587b14551771accd04ff1c78302f9605f44c3894976c5b3537b70cb7ac9dcb5398dc22079"
+}
+
+./ethdo validator exit --epoch 305658 --private-key=0x338cc9dd5d27a9385e79487f597a72250e0f4fd2d6271ea012b8520b5455fc49 --offline --json | jq
+
+{
+  "message": {
+    "epoch": "305658",
+    "validator_index": "200"
+  },
+  "signature": "0x8db88aabdd8f03cebba47cf3df7dd5e06ab9a49f57fc209a00cb73c5ecdea192b6ab0c5965ad8e7b6b63b9d397be3df40ea84150f2ed13ca9e0ba382c24f583ca921ff0364f18e51444838992d628623598c7c12122ff46d
+}
+
+cat offline-preparation.json
+{
+  "version": "3",
+  "genesis_validators_root": "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95",
+  "epoch": "305658",
+  "genesis_fork_version": "0x00000000",
+  "exit_fork_version": "0x03000000",
+  "current_fork_version": "0x04000000",
+  "bls_to_execution_change_domain_type": "0x0a000000",
+  "voluntary_exit_domain_type": "0x04000000",
+  "validators": [
+    {
+      "index": "100",
+      "pubkey": "8844cebb34d10e0e57f3c29ada375dafe14762ab85b2e408c3d6d55ce6d03317660bca9f2c2d17d8fbe14a2529ada1ea",
+      "state": "active_ongoing",
+      "withdrawal_credentials": "0x0100000000000000000000000d369bb49efa5100fd3b86a9f828c55da04d2d50"
+    },
+    {
+      "index": "200",
+      "pubkey": "a15cc019cf4ce59f587d24bd58ae6011c8b638770c3c133cc9f081e161e7db01c92611f1a566b00208dd1e709f6ec716",
+      "state": "active_ongoing",
+      "withdrawal_credentials": "0x0100000000000000000000000d369bb49efa5100fd3b86a9f828c55da04d2d50"
+    }
+  ]
+}
+
+*/
+
+#[test]
+fn test_batch_presigned_exit_message() -> Result<(), Box<dyn std::error::Error>> {
+    let chain = "mainnet";
+    let expected_mnemonic = "ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say";
+    let seed_beacon_mapping = "0:100,2:200";
+    let epoch = "305658";
+
+    // run eth-staking-smith
+    let mut cmd = Command::cargo_bin("eth-staking-smith")?;
+
+    cmd.arg("batch-presigned-exit-message");
+    cmd.arg("--chain");
+    cmd.arg(chain);
+    cmd.arg("--seed_beacon_mapping");
+    cmd.arg(seed_beacon_mapping);
+    cmd.arg("--mnemonic");
+    cmd.arg(expected_mnemonic);
+    cmd.arg("--epoch");
+    cmd.arg(epoch);
+
+    cmd.assert().success();
+
+    let output = &cmd.output()?.stdout;
+    let command_output = std::str::from_utf8(output)?;
+
+    let signed_voluntary_exits: Vec<SignedVoluntaryExit> = serde_json::from_str(command_output)?;
+    let signed_voluntary_exit1 = signed_voluntary_exits.get(0).unwrap();
+    let signed_voluntary_exit2 = signed_voluntary_exits.get(1).unwrap();
+
+    let mut signatures = vec![
+        signed_voluntary_exit1.signature.to_string(),
+        signed_voluntary_exit2.signature.to_string(),
+    ];
+    signatures.sort();
+
+    assert_eq!(
+      signatures,
+      vec![
+        "0x8db88aabdd8f03cebba47cf3df7dd5e06ab9a49f57fc209a00cb73c5ecdea192b6ab0c5965ad8e7b6b63b9d397be3df40ea84150f2ed13ca9e0ba382c24f583ca921ff0364f18e51444838992d628623598c7c12122ff46da795c000ae15dd65",
+        "0xa74f22d26da9934c2a9c783799fb9e7bef49b3d7c3759a0683b52ee5d71516c0ecdbcc47703f11959c5e701a6c47194410bed800217bd4dd0dab1e0587b14551771accd04ff1c78302f9605f44c3894976c5b3537b70cb7ac9dcb5398dc22079",
+      ]
+    );
+
+    Ok(())
+}

--- a/tests/e2e/existing_mnemonic.rs
+++ b/tests/e2e/existing_mnemonic.rs
@@ -18,8 +18,12 @@ use std::{
     generate 1 validator without specifying the mnemonic
     (without withdrawal address specified, i.e. the address is derived from the public key)
     (without kdf specified, i.e. pbkdf2 will be used)
+
+    This test is marked is sequential, because it modifies MNEMONIC
+    environment variable state, which can interfere with the rest of the e2e tests.
 */
 #[test]
+#[serial_test::serial]
 fn test_deposit_data_keystore_mnemonic_as_env_var() -> Result<(), Box<dyn std::error::Error>> {
     let chain = "goerli";
     let expected_decryption_password = "testtest";
@@ -98,6 +102,8 @@ fn test_deposit_data_keystore_mnemonic_as_env_var() -> Result<(), Box<dyn std::e
 
     // check that pbkdf2 was used if nothing else is specified
     assert_eq!("pbkdf2", parse_kdf_function(keystore));
+
+    std::env::remove_var("MNEMONIC");
 
     Ok(())
 }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,3 +1,4 @@
+mod batch_presigned_exit_message;
 mod bls_to_execution_change;
 mod existing_mnemonic;
 mod new_mnemonic;


### PR DESCRIPTION
Currently, `presigned-exit-message` command only allows to generate voluntary exit messages for single validator. It was discovered that sometimes it is important to be able to generate exit messages for given mnemonic in a batch. This PR implements alternative command that takes single mnemonic and generates JSON output containing batch of presigned exit messages, according to `--seed-beacon-mapping` parameter passed.
