### PR TITLE
Allow mnemonic as env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "eth_staking_smith"
 path = "src/lib.rs"
 
 [dependencies]
-clap = { version = "^4.5", features = ["derive"] }
+clap = { version = "^4.5", features = ["derive", "env"] }
 ethereum_hashing = "0.6.0"
 eth2_key_derivation = { git = "https://github.com/ChorusOne/lighthouse", rev = "1be5253610dc8fee3bf4b7a8dc1d01254bc5b57d"}
 eth2_keystore = { git = "https://github.com/ChorusOne/lighthouse", rev = "1be5253610dc8fee3bf4b7a8dc1d01254bc5b57d"}

--- a/README.md
+++ b/README.md
@@ -48,8 +48,15 @@ Regenerate key and deposit data with existing mnemonic:
 
 ### Example command:
 
+with mnemonic in plain text:
 ```
 ./target/debug/eth-staking-smith existing-mnemonic --chain mainnet --keystore_password testtest --mnemonic "entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup" --num_validators 1 --withdrawal_credentials "0x0100000000000000000000000000000000000000000000000000000000000001"
+```
+or with mnemonic as an environment variable `MNEMONIC`:
+
+```
+export MNEMONIC="entire habit bottom mention spoil clown finger wheat motion fox axis mechanic country make garment bar blind stadium sugar water scissors canyon often ketchup"
+./target/debug/eth-staking-smith existing-mnemonic --chain mainnet --keystore_password testtest --num_validators 1 --withdrawal_credentials "0x0100000000000000000000000000000000000000000000000000000000000001"
 ```
 
 ## Using custom testnet config

--- a/src/cli/existing_mnemonic.rs
+++ b/src/cli/existing_mnemonic.rs
@@ -11,10 +11,6 @@ pub struct ExistingMnemonicSubcommandOpts {
     /// 1. Through the MNEMONIC environment variable (recommended)
     ///
     /// 2. Through the --mnemonic argument in plain text.
-    /// It is recommended not to use this
-    /// argument, and wait for the CLI to ask you
-    /// for your mnemonic as otherwise it will
-    /// appear in your shell history.
     #[arg(long, env = "MNEMONIC")]
     pub mnemonic: String,
 

--- a/src/cli/existing_mnemonic.rs
+++ b/src/cli/existing_mnemonic.rs
@@ -6,11 +6,16 @@ pub struct ExistingMnemonicSubcommandOpts {
     /// The mnemonic that you used to generate your
     /// keys.
     ///
+    /// This can be provided in two ways:
+    ///
+    /// 1. Through the MNEMONIC environment variable (recommended)
+    ///
+    /// 2. Through the --mnemonic argument in plain text.
     /// It is recommended not to use this
     /// argument, and wait for the CLI to ask you
-    ///    for your mnemonic as otherwise it will
-    ///    appear in your shell history.
-    #[arg(long)]
+    /// for your mnemonic as otherwise it will
+    /// appear in your shell history.
+    #[arg(long, env = "MNEMONIC")]
     pub mnemonic: String,
 
     /// The name of Ethereum PoS chain you are targeting.

--- a/tests/e2e/existing_mnemonic.rs
+++ b/tests/e2e/existing_mnemonic.rs
@@ -14,15 +14,17 @@ use std::{
 };
 
 /*
-    generate 1 validator with existing mnemonic
+    set the MNEMONIC environment variable
+    generate 1 validator without specifying the mnemonic
     (without withdrawal address specified, i.e. the address is derived from the public key)
     (without kdf specified, i.e. pbkdf2 will be used)
 */
 #[test]
-fn test_deposit_data_keystore() -> Result<(), Box<dyn std::error::Error>> {
+fn test_deposit_data_keystore_mnemonic_as_env_var() -> Result<(), Box<dyn std::error::Error>> {
     let chain = "goerli";
     let expected_decryption_password = "testtest";
     let expected_mnemonic = "ski interest capable knee usual ugly duty exercise tattoo subway delay upper bid forget say";
+    std::env::set_var("MNEMONIC", expected_mnemonic);
     let num_validators = "1";
 
     // test directory
@@ -49,8 +51,6 @@ fn test_deposit_data_keystore() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg(chain);
     cmd.arg("--keystore_password");
     cmd.arg(expected_decryption_password);
-    cmd.arg("--mnemonic");
-    cmd.arg(expected_mnemonic);
     cmd.arg("--num_validators");
     cmd.arg(num_validators);
 


### PR DESCRIPTION
Add support for providing mnemonic phrases via MNEMONIC environment variable, for improved security. 

Users can now either:
- Set `MNEMONIC` environment variable (recommended): Keeps sensitive mnemonic phrases out of shell history
- Use --mnemonic CLI argument as before
